### PR TITLE
Feature/pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # RomiTask
 
+![](https://anaconda.org/romi-eu/romitask/badges/version.svg)
+![](https://anaconda.org/romi-eu/romitask/badges/platforms.svg)
+![](https://anaconda.org/romi-eu/romitask/badges/license.svg)
+
 ## About
 
-This repository gathers scripts and classes needed to run `luigi` based tasks for the ROMI project.
+This repository gathers CLI and classes needed to run `luigi` based tasks for the ROMI project.
 
 Alone, this library does not do much...
 To run a "meaningful" task you need to install other ROMI libraries like `plantdb` and `plant-3d-vision`
@@ -12,25 +16,35 @@ Note that both `plant-3d-vision` & `plant-imager` ROMI libraries have `romitask`
 
 ## Installation
 
-### Conda environment
+We strongly advise to create isolated environments to install the ROMI libraries.
 
-We strongly advise to create a `conda` environment, here named `romitask`:
+We often use `conda` as an environment and python package manager.
+If you do not yet have `miniconda3` installed on your system, have a look [here](https://docs.conda.io/en/latest/miniconda.html).
 
+The `romitask` package is available from the `romi-eu` channel.
+
+### Existing conda environment
+To install the `romitask` conda package in an existing environment, first activate it, then proceed as follows:
 ```shell
-conda create -n romitask 'python>=3.7'
+conda install romitask -c romi-eu
 ```
 
-If you do not yet have `miniconda3` on your system, have a look [here](https://docs.conda.io/en/latest/miniconda.html).
+### New conda environment
+To install the `romitask` conda package in a new environment, here named `romi`, proceed as follows:
+```shell
+conda create -n romi romitask -c romi-eu
+```
 
 ### Installation from sources
+To install this library, simply clone the repo and use `pip` to install it and the required dependencies.
+Again, we strongly advise to create a `conda` environment.
 
-To install this library, simply clone the repo and use `pip` to install it and the required dependencies:
-
+All this can be done as follows:
 ```shell
 git clone https://github.com/romi/romitask.git -b dev  # git clone the 'dev' branch of romitask
 cd romitask
-conda activate romitask  # do not forget to activate your environment!
-python -m pip install -r requirements.txt  # install the dependencies
+conda create -n romi 'python =3.10'
+conda activate romi  # do not forget to activate your environment!
 python -m pip install -e .  # install the sources
 ```
 
@@ -38,9 +52,8 @@ Note that the `-e` option is to install the `romitask` sources in "developer mod
 That is, if you make changes to the source code of `romitask` you will not have to `pip install` it again.
 
 You may want to install the `plantdb` sources to perform the `DummyTask` test example below:
-
 ```shell
-conda activate romitask  # do not forget to activate your environment!
+conda activate romi  # do not forget to activate your environment!
 python -m pip install git+https://github.com/romi/plantdb.git@dev#egg=plantdb # install the `plantdb` sources from 'dev' branch
 ```
 
@@ -49,9 +62,7 @@ This will install the required ROMI library `plantdb`, but not in "developer mod
 ## Usage
 
 ### Create a dummy database
-
 To quickly create a _dummy database_, let's use the temporary folder `/tmp`:
-
 ```shell
 mkdir -p /tmp/dummy_db/dummy_dataset  # create dummy database and dataset
 touch /tmp/dummy_db/romidb  # add the romidb marker (empty file)
@@ -59,15 +70,12 @@ export DB_LOCATION='/tmp/dummy_db'  # add database location as an environment va
 ```
 
 ### Test the CLI with `DummyTask`
-
 To test the CLI `romi_run_task`:
-
 ```shell
 romi_run_task DummyTask $DB_LOCATION/dummy_dataset --module romitask.task
 ```
 
 You should get a "Luigi Execution Summary" similar to this:
-
 ```
 ===== Luigi Execution Summary =====
 
@@ -84,7 +92,6 @@ As no TOML configuration file was provided, you should get a `pipeline.toml` wit
 sections at the root of the `dummy_dataset/` directory.
 
 The `dummy_database` tree structure should look like this:
-
 ```
 dummy_database/
 ├── dummy_dataset/
@@ -99,29 +106,26 @@ dummy_database/
 
 ## Developers & contributors
 
+You first have to install the library from sources as explained [here](#installation-from-sources).
+
 ### Conda packaging
+Start by installing the required `romitask` & `anaconda-client` conda packages in the `base` environment as follows:
+```shell
+conda install -n conda-build anaconda-client
+```
 
+#### Build a conda package
 To build the `romitask` conda package, from the `base` conda environment, run:
-
 ```shell
 conda build conda/recipe/ -c conda-forge --user romi-eu
 ```
 
-This requires the `conda-build` package to be installed in the `base` environment!
-
-```shell
-conda install conda-build
-```
-
+#### Upload a conda package
 To upload the built package, you need a valid account (here `romi-eu`) on [anaconda.org](www.anaconda.org) & to log ONCE
 with `anaconda login`, then:
-
 ```shell
 anaconda upload ~/miniconda3/conda-bld/linux-64/romitask*.tar.bz2 --user romi-eu
 ```
 
-This requires the `anaconda-client` package to be installed in the `base` environment!
-
-```shell
-conda install anaconda-client
-```
+### Documentation
+COMING SOON.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ anaconda upload ~/miniconda3/conda-bld/linux-64/romitask*.tar.bz2 --user romi-eu
 ```
 
 #### Clean builds
+To clean the source and build intermediates:
+```shell
+conda build purge
+```
+
 To clean **ALL** the built packages & build environments:
 ```shell
 conda build purge-all

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You first have to install the library from sources as explained [here](#installa
 ### Conda packaging
 Start by installing the required `romitask` & `anaconda-client` conda packages in the `base` environment as follows:
 ```shell
-conda install -n conda-build anaconda-client
+conda install -n base conda-build anaconda-client
 ```
 
 #### Build a conda package

--- a/README.md
+++ b/README.md
@@ -115,16 +115,30 @@ conda install -n base conda-build anaconda-client
 ```
 
 #### Build a conda package
-To build the `romitask` conda package, from the `base` conda environment, run:
+To build the `romitask` conda package, from the root directory of the repository and the `base` conda environment, run:
 ```shell
 conda build conda/recipe/ -c conda-forge --user romi-eu
 ```
+
+If you are struggling with some of the modifications you made to the recipe, 
+notably when using environment variables or Jinja2 stuffs, you can always render the recipe with:
+```shell
+conda render conda/recipe/
+```
+
+The official documentation for `conda-render` can be found [here](https://docs.conda.io/projects/conda-build/en/stable/resources/commands/conda-render.html).
 
 #### Upload a conda package
 To upload the built package, you need a valid account (here `romi-eu`) on [anaconda.org](www.anaconda.org) & to log ONCE
 with `anaconda login`, then:
 ```shell
 anaconda upload ~/miniconda3/conda-bld/linux-64/romitask*.tar.bz2 --user romi-eu
+```
+
+#### Clean builds
+To clean **ALL** the built packages & build environments:
+```shell
+conda build purge-all
 ```
 
 ### Documentation

--- a/conda/env/romitask.yaml
+++ b/conda/env/romitask.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - romi-eu
 dependencies:
-  - python >=3.7,<3.10
+  - python >=3.7
   - colorlog
   - luigi
   - tqdm

--- a/conda/recipe/build.sh
+++ b/conda/recipe/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-"${PYTHON}" -m pip install .

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,18 +1,23 @@
-{% set data = load_setup_py_data() %}  # loads data from the `setup.py` file
-{% set version = data.get('version') %}  # get the 'version' from loaded data
-{% set summary = data.get('description') %}  # get the 'description' from loaded data
+{% set pyproject = load_file_data('../../pyproject.toml', 'toml', from_recipe_dir=True) %}
+{% set project = pyproject.get('project', {}) %}
+{% set deps = project.get('dependencies', {}) %}
+{% set urls = project.get('urls', {}) %}
 # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#loading-data-from-other-files
+# Source code for Jinja context: https://github.com/conda/conda-build/blob/main/conda_build/jinja_context.py
+# Then search for the `load_file_data` function.
+
 package:
-  name: romitask
-  version: {{ version }}
+  name: {{ project.get('name') }}
+  version: {{ project.get('version') }}
 
 source:
-  path: ../../
+  path: ../../  # to build from cloned sources
 #  git_url: https://github.com/romi/romitask.git
 #  git_tag: dev
 
 build:
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  string: {{ environ.get('GIT_DESCRIBE_HASH', 'latest') }}
+  script: python -m pip install .
 
 requirements:
   build:
@@ -20,26 +25,24 @@ requirements:
     - python  {{ python }}
   run:
     - python  {{ python }}
-    - colorlog
-    - luigi
-    - tqdm
-    - toml
-    - watchdog
+    {% for dep in deps %}
+    - {{ dep }}
+    {% endfor %}
 
 test:
   imports:
     - romitask  # test the import of romitask
   commands:
     - romi_run_task -h
+    - print_task_info -h
 
 about:
-  home: https://docs.romi-project.eu/plant_imager/
+  home: {{ urls.get('Homepage') }}
   license: LGPL-3.0-or-later
   license_file: LICENSE
-  summary: {{ summary }}
+  summary: {{ project.get('description') }}
   description: |
     The _3D plant phenotyping platform_ of the ROMI project allows to performs a full 3D analysis of plants.
     It combines an imaging station with a powerful image processing pipeline, to build a 3D representation of plants.
     This package is intended to provide the common CLI to performs any predefined task.
-  dev_url: https://github.com/romi/romitask
-  doc_source_url: https://docs.romi-project.eu/plant_imager/
+  dev_url: {{ urls.get('Repository') }}

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 #  git_tag: dev
 
 build:
-  string: {{ environ.get('GIT_DESCRIBE_HASH', 'latest') }}
+  string: {{ 'py'+ PY_VER.replace('.','') + '_' + environ.get('GIT_DESCRIBE_HASH', 'latest') }}
   script: python -m pip install .
 
 requirements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ build-backend = "setuptools.build_meta"
 name = "romitask"
 version = "0.11.01"
 dependencies = [
-    "luigi",
-    "tqdm",
-    "toml",
-    "watchdog",
+    "numpy",
     "colorlog",
+    "luigi",
+    "toml",
+    "tqdm",
+    "watchdog",
 #    "plantdb @ git+https://github.com/romi/plantdb.git@dev"
 ]
 description = "The ROMI task runner, a luigi based task pipeline."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "romitask"
+version = "0.11.01"
+dependencies = [
+    "luigi",
+    "tqdm",
+    "toml",
+    "watchdog",
+    "colorlog",
+#    "plantdb @ git+https://github.com/romi/plantdb.git@dev"
+]
+description = "The ROMI task runner, a luigi based task pipeline."
+readme = "README.md"
+requires-python = ">=3.7"
+license = { file = "LICENSE" }
+authors = [
+    { name = "Nabil Ait Taleb", email = "mohamednabil.aittaleb@sony.com" },
+    { name = "Timothée Wintz", email = "timothee@timwin.fr" },
+]
+maintainers = [
+    { name = "Jonathan Legrand", email = "jonathan.legrand@ens-lyon.fr" }
+]
+keywords = [
+    "Robotics for Microfarms",
+    "ROMI",
+    "Runner",
+    "Luigi",
+    "Pipeline",
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)"
+]
+
+[project.scripts]
+print_task_info = "romitask.cli.print_task_info:main"
+romi_run_task = "romitask.cli.romi_run_task:main"
+
+[project.urls]
+Homepage = "https://romi-project.eu/"
+Documentation = "https://docs.romi-project.eu/plant_imager/"
+Repository = "https://github.com/romi/romitask"
+Issues = "https://github.com/romi/romitask/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-# -*- coding: utf-8 -*-
-luigi
-tqdm
-toml
-watchdog
-colorlog
-#plantdb @ git+https://github.com/romi/plantdb.git@dev

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from setuptools import find_packages
-from setuptools import setup
+import setuptools
 
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
-
-opts = dict(
-    name="romitask",
-    version="0.10.99",
-    description="The ROMI task runner, a luigi based task pipeline.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Nabil Ait Taleb",
-    author_email="mohamednabil.aittaleb@sony.com",
-    maintainer='Jonathan Legrand',
-    maintainer_email='jonathan.legrand@ens-lyon.fr',
-    url="https://docs.romi-project.eu/Scanner/home/",
-    download_url='',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    scripts=[
-        'bin/romi_run_task',
-        'bin/print_task_info'
-    ],
-    zip_safe=False,
-    python_requires='>=3.7',
-    install_requires=[],
-    include_package_data=True
-)
-
-if __name__ == '__main__':
-    setup(**opts)
+setuptools.setup()

--- a/src/romitask/cli/print_task_info.py
+++ b/src/romitask/cli/print_task_info.py
@@ -272,44 +272,47 @@ def list_configured_tasks(toml_conf):
     return list(toml_conf.keys())
 
 
-""""""
-args = parsing().parse_args()
+def main():
+    args = parsing().parse_args()
 
-config = toml.load(os.path.join(args.db_path, "pipeline.toml"))
+    config = toml.load(os.path.join(args.db_path, "pipeline.toml"))
     # conf_tasks = list_configured_tasks(config)
-print(f"# -- Summary of task {args.task}:")
-print("# - Used TOML configuration:")
-try:
-    print(config[args.task])
-except KeyError:
-    print(f"Task '{args.task}' is not defined in the configuration file!")
+    print(f"# -- Summary of task {args.task}:")
+    print("# - Used TOML configuration:")
+    try:
+        print(config[args.task])
+    except KeyError:
+        print(f"Task '{args.task}' is not defined in the configuration file!")
 
-print("\n# - Generated metadata:")
-md_path = os.path.join(args.db_path, 'metadata')
-json_list = [f for f in os.listdir(md_path) if f.startswith(args.task) and f.endswith('.json')]
-if json_list == []:
-    raise IOError("Could not find the JSON metadata file associated to task '{}' in dataset '{}'!".format(args.task,
+    print("\n# - Generated metadata:")
+    md_path = os.path.join(args.db_path, 'metadata')
+    json_list = [f for f in os.listdir(md_path) if f.startswith(args.task) and f.endswith('.json')]
+    if json_list == []:
+        raise IOError("Could not find the JSON metadata file associated to task '{}' in dataset '{}'!".format(args.task,
                                                                                                               args.db_path))
-elif len(json_list) == 1:
-    md_json = json_list[0]
-    print("Found a JSON metadata file associated to task '{}' in dataset '{}'!".format(args.task, args.db_path))
-    md_json = os.path.join(md_path, md_json)
-else:
-    print("Found more than one JSON metadata file associated to task '{}' in dataset '{}':".format(args.task,
+    elif len(json_list) == 1:
+        md_json = json_list[0]
+        print("Found a JSON metadata file associated to task '{}' in dataset '{}'!".format(args.task, args.db_path))
+        md_json = os.path.join(md_path, md_json)
+    else:
+        print("Found more than one JSON metadata file associated to task '{}' in dataset '{}':".format(args.task,
                                                                                                        args.db_path))
-    [print(" - {}".format(json_f)) for json_f in json_list]
-    md_json = max([os.path.join(md_path, json_f) for json_f in json_list], key=os.path.getctime)
-    print("The most recent one is '{}'".format(os.path.split(md_json)[-1]))
+        [print(" - {}".format(json_f)) for json_f in json_list]
+        md_json = max([os.path.join(md_path, json_f) for json_f in json_list], key=os.path.getctime)
+        print("The most recent one is '{}'".format(os.path.split(md_json)[-1]))
 
-task_id = os.path.splitext(os.path.split(md_json)[-1])[0]
-print("{} task recorded the following parameters metadata:".format(task_id))
-md_json = json.load(open(md_json, 'r'))
-print(json.dumps(md_json, sort_keys=True, indent=2))
+    task_id = os.path.splitext(os.path.split(md_json)[-1])[0]
+    print("{} task recorded the following parameters metadata:".format(task_id))
+    md_json = json.load(open(md_json, 'r'))
+    print(json.dumps(md_json, sort_keys=True, indent=2))
 
-print("\n# - Task outputs:")
-try:
-    info_from_task(args.task, task_id, args.db_path)
-except FileNotFoundError as e:
-    print(e)
-    print("ERROR: No task output file found! Maybe it did not finish ?!")
+    print("\n# - Task outputs:")
+    try:
+        info_from_task(args.task, task_id, args.db_path)
+    except FileNotFoundError as e:
+        print(e)
+        print("ERROR: No task output file found! Maybe it did not finish ?!")
 
+
+if __name__ == "__main__":
+    main()

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -530,8 +530,7 @@ def run_task(args):
 
     return
 
-
-if __name__ == '__main__':
+def main():
     # - Parse the input arguments to variables:
     parser = parsing()
     args = parser.parse_args()
@@ -591,3 +590,6 @@ if __name__ == '__main__':
                 print(e)
     else:
         run_task(args)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Update to modern standards in Python packaging using the `pyproject.toml`.
Keep a minimal `setup.py` file.
Remove the now obsolete `requirements.txt` file.
Update the README.
Update the conda packaging to use the information provided by `pyproject.toml`.
Conda build string with python version (without dot) and commit hash: `py<version>_<commit_short_hash>`.

Notes:
 - We use `setuptools` as build-backend.
 - Not sure yet how to add `plantdb` as dependency.