### PR TITLE
Enhance ROMI task defaults, config handling, and CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "colorlog",
     "dotenv",
     "luigi",
-    "toml",
+    "tomlkit",
     "tqdm",
     "watchdog",
 ]

--- a/src/romitask/cli/print_task_info.py
+++ b/src/romitask/cli/print_task_info.py
@@ -32,7 +32,7 @@ import json
 import os
 
 import numpy as np
-import toml
+import tomlkit
 
 from romitask.modules import TASKS
 
@@ -275,7 +275,7 @@ def list_configured_tasks(toml_conf):
 def main():
     args = parsing().parse_args()
 
-    config = toml.load(os.path.join(args.db_path, "pipeline.toml"))
+    config = tomlkit.load(os.path.join(args.db_path, "pipeline.toml"))
     # conf_tasks = list_configured_tasks(config)
     print(f"# -- Summary of task {args.task}:")
     print("# - Used TOML configuration:")

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -273,7 +273,7 @@ def get_task_predefined_module(task: str, logger) -> str:
     return module
 
 
-def create_backup_cfg(path: str | Path, cfgname: str, config: dict) -> str:
+def create_backup_cfg(path: str | Path, cfgname: str, config: dict[str, dict[str, Any]]) -> str:
     """Create the backup configuration file used by luigi.
 
     Parameters
@@ -321,8 +321,14 @@ def create_backup_cfg(path: str | Path, cfgname: str, config: dict) -> str:
                          "not_run": 25, "task_failed": 30,
                          "scheduling_error": 35, "unhandled_exception": 40}
 
-    # Save the libraries version:
+    # Save the version number for each ROMI library:
     config["version"] = get_version()
+
+    compat_cfg = copy.copy(config)
+    for task_name, task_params in compat_cfg.items():
+        # Convert any list or dict task parameter value to a string for compatibility:
+        compat_cfg[task_name] = {param_name: str(param) if isinstance(param, (list, dict)) else param for param_name, param in task_params.items()}
+        compat_cfg[task_name] = {param_name: param for param_name, param in task_params.items() if param}
 
     with open(file_path, 'w') as f:
         tomlkit.dump(compat_cfg, f)

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -481,17 +481,21 @@ def run_task(dataset_path: str | Path,
 
     # - Process given PIPELINE configuration directory OR file, if any:
     if isinstance(config, dict):
+        # Use directly the given config dictionary:
         logger.info("Loading configuration from dictionary.")
     elif os.path.isdir(config):
+        # Load all config files from the given directory, if any, to a single config dictionary:
         config = load_config_from_directory(config, logger=logger)
     elif os.path.isfile(config):
+        # Load config file to a config dictionary:
         config = load_config_from_file(config, logger=logger)
     elif config != "":
         logger.critical(f"Could not understand `config` option '{config}'!")
         sys.exit("Error with configuration file!")
     else:
-        if bak_pipe_config is None:
-            logger.info("Using NO configuration!")
+        if not bak_pipe_config:
+            config = {}
+            logger.warning("Using full default configuration!")
         else:
             config = bak_pipe_config
             logger.info("Using a PREVIOUS pipeline configuration!")
@@ -501,7 +505,7 @@ def run_task(dataset_path: str | Path,
 
     # - Look for "local" PIPELINE configuration file(s) to load:
     local_path = copy.copy(dataset_path)
-    local_toml = list(local_path.glob('*.toml'))
+    local_toml = sorted(local_path.glob('*.toml'), reverse=True)  # maintain resolution order, priority goes from first to last in alphabetical order
     local_toml = [f for f in local_toml if f.name != SCAN_TOML]  # exclude SCAN backup TOML config
     local_toml = [f for f in local_toml if f.name != PIPE_TOML]  # exclude PIPELINE backup TOML config
     # - Load the local configuration from detected file(s):

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -355,7 +355,7 @@ def check_dataset_directory(path: Path, task: str, logger: Logger) -> str:
 
     Notes
     -----
-    If a "Scan" like tasks is required, a directory should be created to receive the created fileset.
+    If a "Scan" like task is required, a directory should be created to receive the created fileset.
     Else, the dataset directory should exist as an existing fileset will be processed.
     """
     if task == "ScannerToCenter":
@@ -399,14 +399,17 @@ def update_config(config: dict, update: dict) -> dict:
     Notes
     -----
     We update only the values from the update dictionary without removing any existing keys.
-
     """
-    from collections.abc import Mapping
-    for k, v in update.items():
-        if isinstance(v, Mapping):
-            config[k] = update_config(config.get(k, {}), v)
-        else:
-            config[k] = v
+    for task_name, task_params in update.items():
+        for tp_name, tp_value in task_params.items():
+            try:
+                if not config.get(task_name):
+                    config[task_name] = {}
+                config[task_name][tp_name] = tp_value
+            except TypeError:
+                print(f"Could not update '{task_name}.{tp_name}': {tp_value}")
+                print(f"{config[task_name][tp_name]=}")
+                raise
     return config
 
 
@@ -485,15 +488,16 @@ def run_task(dataset_path: str | Path,
     local_toml = [f for f in local_toml if f.name != SCAN_TOML]  # exclude SCAN backup TOML config
     local_toml = [f for f in local_toml if f.name != PIPE_TOML]  # exclude PIPELINE backup TOML config
     # - Load the local configuration from detected file(s):
-    local_config = {}
     if len(local_toml) > 0:
+        local_config = {}
         logger.info(f"Found {len(local_toml)} local TOML configuration file{'s' if len(local_toml) > 1 else ''}!")
         for f in local_toml:
-            local_config.update(load_config_from_file(str(f), logger=logger))
+           local_config = update_config(local_config, load_config_from_file(str(f), logger=logger))
         if local_config != {}:
             logger.info(f"Got local definitions for: {list(local_config.keys())}")
+            logger.debug(f"{local_config=}")
             # Update the given PIPELINE configuration with the local configuration:
-            update_config(config, local_config)
+            config = update_config(config, local_config)
             logger.info("Updated given configuration with local definitions!")
 
     # Apply CLI override (manual definition of parameters)
@@ -554,10 +558,10 @@ def run_task(dataset_path: str | Path,
 
         # - Print or Start the configured pipeline:
         if kwargs.get('dry_run', False):
-            logger.info(f"Luigi command to call is:\n{cmd}")
+            logger.info(f"Luigi command to call is:\n{' '.join(list(map(str, cmd)))}")
         else:
             t_start = time.time()
-            logger.debug(f"Running luigi command: {cmd}")
+            logger.info(f"Running luigi command:\n{' '.join(list(map(str, cmd)))}")
             logger.debug(f"Using locally defined varenv: {env}")
             logger.debug(f"Using globally defined varenv: {os.environ}")
             # System‑wide variables (`os.environ`) overwrite any duplicate keys from the custom `env` dict

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -23,31 +23,49 @@
 # <https://www.gnu.org/licenses/>.
 # ------------------------------------------------------------------------------
 
-"""ROMI tasks CLI.
+"""
+# CLI to execute ROMI Luigi tasks
 
-It is intended to be used as the main program to run the various tasks defined in ``MODULES``.
+A lightweight wrapper that launches ROMI‑specific Luigi tasks from the command line (or programmatically).
+It loads and merges configuration files, validates dataset directories, prepares logging, sets up environment variables, and finally invokes Luigi with the appropriate module and task.
+This makes complex pipeline execution simple, reproducible, and portable.
 
-It uses ``luigi`` paradigm with ``Task``, ``Target`` & ``Parameters`` defined
-for each ``RomiTask`` in their module.
+## Key Features
 
-The program uses two config files stored in the root scan dataset folder:
+- **Unified CLI entry point** (`romi_run_task.py`) to run any pre‑defined ROMI task.
+- **Automatic configuration handling**: loads backup `scan.toml` / `pipeline.toml`, merges multiple local TOML files, and applies CLI overrides.
+- **Dynamic module resolution**: selects the correct Python module for a task, with optional manual override.
+- **Dataset validation**: ensures the dataset directory matches the expectations of the selected task (creation vs. processing).
+- **Robust logging**: generates per‑task log files, configurable log level, and temporary logging configuration passed to Luigi.
+- **Environment preparation**: injects `.env` variables, sets `LUIGI_CONFIG_PATH`, `PYOPENCL_CTX`, and optional DB authentication flags.
+- **Dry‑run mode**: prints the full Luigi command without executing it, useful for debugging.
+- **Authentication options**: support for DB credentials or a “no‑auth” testing mode.
+- **Local scheduler by default**: runs the Luigi scheduler locally unless overridden.
+- **Programmatic API**: `run_task()` can be called from Python code for tighter integration.
 
-  - ``scan.toml``: the last configuration used with the 'Scan' module;
-  - ``pipeline.toml``: the last configuration used with any other module.
+## Usage Examples
 
+### 1. Command‑line execution
+Run a `Scan` task to create a dataset `scan01` located at `/data/ROMI/` with a custom configuration:
 
-They define tasks parameters that will override the default tasks parameters
-using luigi's "config ingestion" [^1] and ROMI configuration classes.
+```shell
+romi_run_task Scan /data/ROMI/scan01 --config /path/to/my/config.toml
+```
 
-The tasks "CalibrationScan", "IntrinsicCalibrationScan", "Scan" & "VirtualScan"
-requires a non-existent or empty dataset directory.
-The other tasks requires a dataset directory populated by images from one of
-the previously named task.
+### 2. Programmatic use from Python
+```python
+>>> from pathlib import Path
+>>> from romitask.cli.romi_run_task import run_task
+>>> dataset = Path("/data/scan01")
+>>> config_path = "/path/to/config.toml"
+>>> run_task(dataset_path=dataset, task="Scan", config=config_path, db_user="my_user", db_password="secret")
+```
+
+The call performs the same steps as the CLI, loading configurations, preparing logging, and invoking Luigi.
 
 References
 ----------
 [^1]: https://luigi.readthedocs.io/en/stable/configuration.html#parameters-from-config-ingestion
-
 """
 
 import copy
@@ -94,7 +112,7 @@ LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
 def load_backup_scan_cfg(path: str | Path) -> dict:
-    """Try to load ``SCAN_TOML`` configuration from path.
+    """Try to load a ``SCAN_TOML`` configuration from the given path.
 
     Parameters
     ----------
@@ -104,7 +122,7 @@ def load_backup_scan_cfg(path: str | Path) -> dict:
     Returns
     -------
     dict
-        The configuration dictionary, if loaded from backup file.
+        The configuration dictionary, if loaded from a backup file.
     """
     scan_last_cfg = os.path.join(path, SCAN_TOML)
     bak_scan_config = {}
@@ -115,7 +133,7 @@ def load_backup_scan_cfg(path: str | Path) -> dict:
 
 
 def load_backup_pipe_cfg(dataset_path: Path, task: str, logger: Logger) -> dict:
-    """Try to load ``PIPE_TOML`` configuration from path.
+    """Try to load a ``PIPE_TOML`` configuration from the given path.
 
     Parameters
     ----------
@@ -129,7 +147,7 @@ def load_backup_pipe_cfg(dataset_path: Path, task: str, logger: Logger) -> dict:
     Returns
     -------
     dict
-        The configuration dictionary, if loaded from backup file.
+        The configuration dictionary, if loaded from a backup file.
     """
     bak_pipe_path = dataset_path / PIPE_TOML
     bak_pipe_config = {}
@@ -147,7 +165,7 @@ def load_backup_pipe_cfg(dataset_path: Path, task: str, logger: Logger) -> dict:
 
 
 def load_config_from_directory(path: str | Path, logger: Logger) -> dict:
-    """Load TOML & JSON configuration files from path.
+    """Load the TOML & JSON configuration files from the given path.
 
     Parameters
     ----------
@@ -192,7 +210,7 @@ def load_config_from_directory(path: str | Path, logger: Logger) -> dict:
 
 
 def load_config_from_file(path: str | Path, logger: Logger) -> dict:
-    """Load TOML configuration file from path.
+    """Load the TOML configuration file from the given path.
 
     Parameters
     ----------
@@ -293,7 +311,6 @@ def create_backup_cfg(path: str | Path, cfgname: str, config: dict[str, dict[str
     Notes
     -----
     We append "return codes" and "library versioning" to the given configuration dictionary.
-
     """
     file_path = os.path.join(path, cfgname)
 
@@ -437,7 +454,7 @@ def run_task(dataset_path: str | Path,
         A logger to use with this method, default to the global logger named `LOGGER_NAME`.
     log_fname : str
         The log file name to use.
-        Defaults to use the standardised log filename with the date and task name from `get_log_filename`.
+        Defaults to use the standardized log filename with the date and task name from `get_log_filename`.
     log_level : {'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'}
         The logging level to use, defaults to 'INFO'.
     luigicmd : str

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -81,6 +81,7 @@ from romitask.modules import DATA_CREATION_TASK
 from romitask.modules import MODULES
 from romitask.modules import NO_DATASET_TASK
 from romitask.modules import TASKS
+from romitask.task_defaults import update_config_with_defaults
 from romitask.utils import get_version
 from romitask.utils import parse_kbdi
 
@@ -462,6 +463,9 @@ def run_task(dataset_path: str | Path,
             config = bak_pipe_config
             logger.info("Using a PREVIOUS pipeline configuration!")
 
+    # Update the loaded config undefined task values with default task values from classes implementation
+    config = update_config_with_defaults(config, MODULES)
+
     # - Look for "local" PIPELINE configuration file(s) to load:
     local_path = copy.copy(dataset_path)
     local_toml = list(local_path.glob('*.toml'))
@@ -585,7 +589,7 @@ def run_task(dataset_path: str | Path,
     default="",
     help="Pipeline configuration file (TOML) or directory. "
          "If a file, read the configuration from it. "
-         "If a directory, read & concatenate all configuration files in it. "
+         "If a directory, read & concatenate all TOML configuration files in it. "
          "By default, search a 'pipeline.toml' file in the selected dataset directory."
 )
 @click.option(

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -413,6 +413,7 @@ def update_config(config: dict, update: dict) -> dict:
 def run_task(dataset_path: str | Path,
              task: str,
              config: str | Path | dict,
+             cfg_override: dict[str, Any] | None = None,
              **kwargs: Any) -> None:
     """Load the configuration to use and call the luigi command to run the selected task.
 
@@ -424,6 +425,8 @@ def run_task(dataset_path: str | Path,
         The name of the task to execute by luigi.
     config : pathlib.Path or str or dict
         The configuration path or dictionary.
+    cfg_override : dict, optional
+        A configuration dictionary that defines tasks and parameters that override the values from `config`.
 
     Other Parameters
     ----------------
@@ -492,8 +495,11 @@ def run_task(dataset_path: str | Path,
             # Update the given PIPELINE configuration with the local configuration:
             update_config(config, local_config)
             logger.info("Updated given configuration with local definitions!")
-        else:
-            logger.error(f"Failed to load local TOML configuration file{'s' if len(local_toml) > 1 else ''}!")
+
+    # Apply CLI override (manual definition of parameters)
+    if cfg_override:
+        for task_override, param_override in cfg_override.items():
+            config[task_override] = {**config.get(task_override, {}), **param_override}
 
     # - Set the name of the module to be loaded for the selected task:
     module = get_task_module(task, logger=logger, module=kwargs.get("module", None))
@@ -603,6 +609,12 @@ def run_task(dataset_path: str | Path,
          "By default, search a 'pipeline.toml' file in the selected dataset directory."
 )
 @click.option(
+    '--cfg',
+    'cfg_override',
+    default="",
+    help="Override configuration file using specific parameters, e.g. \"Clean.keep_task='Masks'\"."
+)
+@click.option(
     '--module',
     default=None,
     help="Library and module of the task. "
@@ -654,6 +666,7 @@ def main(
         task: str,
         dataset_path: tuple[str, ...],
         config: str,
+        cfg_override: str,
         module: Optional[str],
         log_level: LogLevel,
         dry_run: bool,
@@ -722,6 +735,16 @@ def main(
         if isinstance(folders, list) and len(folders) == 0:
             _dataset_path_error(dataset_path)
 
+    # Try to parse the cfg_override string or default to `None`
+    if cfg_override:
+        try:
+            cfg_override = tomlkit.loads(cfg_override)
+        except Exception as e:
+            logger.critical(f"Could not parse a TOML config from '{cfg_override}': {e}")
+            cfg_override = None
+    else:
+        cfg_override = None
+
     # Finally, we can call the main `run_task` method:
     if isinstance(folders, list):
         ## For each folder:
@@ -731,7 +754,7 @@ def main(
             print("\n")  # to facilitate the search in the console by separating the datasets
             logger.info(f"Processing dataset '{Path(dataset_path_item).name}'.")
             try:
-                run_task(dataset_path_item, task, config,
+                run_task(dataset_path_item, task, config, cfg_override,
                          log_level=log_level, luigicmd=luigicmd, module=module,
                          local_scheduler=local_scheduler, dry_run=dry_run,
                          no_auth=no_auth, db_user=db_user, db_password=db_password)
@@ -739,7 +762,7 @@ def main(
                 print(e)
     else:
         ## For the folder:
-        run_task(folders, task, config,
+        run_task(folders, task, config, cfg_override,
                  log_level=log_level, luigicmd=luigicmd, module=module,
                  local_scheduler=local_scheduler, dry_run=dry_run,
                  no_auth=no_auth, db_user=db_user, db_password=db_password)

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -67,7 +67,7 @@ from typing import Literal
 from typing import Optional
 
 import click
-import toml
+import tomlkit
 from click_option_group import optgroup
 from dotenv import dotenv_values
 
@@ -108,8 +108,8 @@ def load_backup_scan_cfg(path: str | Path) -> dict:
     """
     scan_last_cfg = os.path.join(path, SCAN_TOML)
     bak_scan_config = {}
-    if os.path.isfile(scan_last_cfg):
-        bak_scan_config = toml.load(scan_last_cfg)
+    with open(scan_last_cfg, "r", encoding="utf-8") as f:
+        bak_scan_config = tomlkit.load(f)
 
     return bak_scan_config
 
@@ -140,7 +140,8 @@ def load_backup_pipe_cfg(dataset_path: Path, task: str, logger: Logger) -> dict:
             logger.critical(f"Task '{task}' was called with dataset '{dataset_path}'!")
             logger.critical(f"It contains a processing pipeline configuration backup file!")
             sys.exit(f"Requested {task} task in non-empty folder, clean it up or change location!")
-        bak_pipe_config = toml.load(bak_pipe_path)
+        with open(bak_pipe_path, "r", encoding="utf-8") as f:
+            bak_pipe_config = tomlkit.load(f)
 
     return bak_pipe_config
 
@@ -179,7 +180,8 @@ def load_config_from_directory(path: str | Path, logger: Logger) -> dict:
     # Read TOML configs
     for f in toml_list:
         try:
-            c = toml.load(f)
+            with open(f, "r", encoding="utf-8") as fp:
+                c = tomlkit.load(fp)
             config.update(c)  # update the config with the new one
         except:
             logger.warning(f"Could not process TOML config file: {f}")
@@ -212,7 +214,8 @@ def load_config_from_file(path: str | Path, logger: Logger) -> dict:
         logger.critical(f"Could not configuration find file: '{path.absolute()}'")
     # Try to load the TOML configuration file:
     try:
-        config = toml.load(path)
+        with open(path, "r", encoding="utf-8") as f:
+            config = tomlkit.load(f)
     except:
         if not path.suffix == ".toml":
             logger.critical(f"Could not load TOML configuration file '{path}'!")
@@ -322,7 +325,8 @@ def create_backup_cfg(path: str | Path, cfgname: str, config: dict) -> str:
     config["version"] = get_version()
 
     with open(file_path, 'w') as f:
-        toml.dump(config, f)
+        tomlkit.dump(compat_cfg, f)
+
     return file_path
 
 

--- a/src/romitask/task.py
+++ b/src/romitask/task.py
@@ -1068,7 +1068,7 @@ class Clean(RomiTask):
             Dictionary mapping task names to their upstream task names.
             For example: {"Masks": "Undistort", "Voxels": "Masks", ...}
         """
-        import toml
+        import tomlkit
         from romitask.task_defaults import update_config_with_defaults
         from romitask.modules import MODULES
 
@@ -1080,7 +1080,7 @@ class Clean(RomiTask):
 
         task_dependencies = {}
         try:
-            config = toml.load(backup_path)
+            config = tomlkit.load(backup_path)
             # Update the loaded config undefined task values with default task values from classes implementation
             config = update_config_with_defaults(config, MODULES)
 

--- a/src/romitask/task.py
+++ b/src/romitask/task.py
@@ -23,13 +23,14 @@
 # <https://www.gnu.org/licenses/>.
 # ------------------------------------------------------------------------------
 
-"""Task Management System for ROMI Project
+"""
+# Task Management System for ROMI Project
 
 A comprehensive task management framework that provides base classes and utilities for defining, executing, and managing data processing tasks in the ROMI (RObot for MIcrofarm) project.
 This module implements a dependency-aware task system with database integration for managing plant imaging and analysis workflows.
 
-Key Features
-------------
+## Key Features
+
 - Task dependency management through upstream task declarations
 - File and dataset existence verification
 - Database-integrated file management system
@@ -43,8 +44,9 @@ Key Features
 - Virtual plant object handling
 - Error handling and failure management
 
-Usage Examples
---------------
+## Usage Examples
+
+```python
 >>> # Creating a simple task
 >>> class MyProcessingTask(RomiTask):
 ...     upstream_task = "PreviousTask"
@@ -64,6 +66,7 @@ Usage Examples
 ...     def f(self, file):
 ...         # Process individual file
 ...         return processed_data
+```
 """
 
 import concurrent.futures
@@ -78,12 +81,14 @@ from typing import Iterable
 import luigi
 from tqdm import tqdm
 
+import plantdb.commons.fsdb.core
 from plantdb.commons.fsdb.core import FSDB
 from plantdb.commons.fsdb.exceptions import FilesetExistsError
 from plantdb.commons.fsdb.exceptions import NotAnFSDBError
 from plantdb.commons.fsdb.validation import _is_fsdb
 from plantdb.commons.io import read_json
 from plantdb.commons.io import write_json
+from plantdb.commons.utils import locate_task_filesets
 from romitask.log import get_logger
 from romitask.utils import ask_confirmation
 
@@ -271,7 +276,7 @@ class ScanConfiguration(luigi.Config):
     >>> type(scan_cfg.scan)
     plantdb.commons.fsdb.Scan
     """
-    scan = ScanParameter()
+    scan: plantdb.commons.fsdb.core.Scan = ScanParameter()
 
 
 class FilesetTarget(luigi.Target):
@@ -1003,6 +1008,10 @@ class Clean(RomiTask):
     keep_metadata : luigi.listParameter
         list of metadata to keep (retain) in the `images` fileset metadata.
         Default to ``IMAGES_MD``.
+    keep_task : luigi.Parameter, optional
+        Task name to keep along with all its upstream dependencies.
+        If specified, this task and all anterior tasks will be preserved.
+        Default to empty string (keep nothing).
 
     See Also
     --------
@@ -1013,6 +1022,7 @@ class Clean(RomiTask):
     no_confirm = luigi.BoolParameter(default=False)
     keep_metadata = luigi.ListParameter(default=[])
     keep_pipeline_cfg = luigi.BoolParameter(default=True)
+    keep_task = luigi.Parameter(default="")
 
     def requires(self):
         """No requirements here."""
@@ -1042,6 +1052,102 @@ class Clean(RomiTask):
             The union of ``user_keep`` and :data:`~romitask.task.IMAGES_MD`.
         """
         return set(user_keep).union(IMAGES_MD)
+
+    @staticmethod
+    def _parse_pipeline_toml(scan: "Scan") -> dict[str, str]:
+        """Parse the pipeline.toml configuration file to extract task dependencies.
+
+        Parameters
+        ----------
+        scan:
+            The active scan.
+
+        Returns
+        -------
+        dict[str, str]
+            Dictionary mapping task names to their upstream task names.
+            For example: {"Masks": "Undistort", "Voxels": "Masks", ...}
+        """
+        import toml
+        from romitask.task_defaults import update_config_with_defaults
+        from romitask.modules import MODULES
+
+        backup_path = Path(scan.path()) / "pipeline.toml"
+
+        if not backup_path.is_file():
+            logger.warning("No pipeline.toml found at %s", backup_path)
+            return {}
+
+        task_dependencies = {}
+        try:
+            config = toml.load(backup_path)
+            # Update the loaded config undefined task values with default task values from classes implementation
+            config = update_config_with_defaults(config, MODULES)
+
+            for task_name, task_config in config.items():
+                # Collect any keys that start with "upstream_"
+                upstream_keys = [k for k in task_config.keys() if k.startswith("upstream_")]
+                if isinstance(task_config, dict) and upstream_keys:
+                    if len(upstream_keys) == 1:
+                        if task_config[upstream_keys[0]] is not None:
+                            # If only one upstream key, store its value directly.
+                            task_dependencies[task_name] = task_config[upstream_keys[0]]
+                    else:
+                        # If multiple, store a list of all upstream values.
+                        task_dependencies[task_name] = [task_config[key] for key in upstream_keys if task_config[key] is not None]
+            logger.info("Parsed pipeline dependencies: %s", task_dependencies)
+            return task_dependencies
+        except Exception as e:
+            logger.error("Failed to parse pipeline.toml: %s", e)
+            return {}
+
+    @staticmethod
+    def _compute_task_hierarchy(task_name: str, dependencies: dict[str, str]) -> set[str]:
+        """Compute all upstream tasks (ancestors) for a given task.
+
+        Parameters
+        ----------
+        task_name:
+            The task name for which to compute the hierarchy.
+        dependencies:
+            Dictionary mapping task names to their upstream task names.
+
+        Returns
+        -------
+        set[str]
+            Set of all task names that should be preserved, including the input task
+            and all its ancestors up to the root.
+        """
+        import networkx as nx
+
+        # Build a directed graph from the dependencies
+        G = nx.DiGraph()
+
+        # Add all edges (task -> upstream_task)
+        for task, upstream in dependencies.items():
+            if not task or not upstream:
+                continue
+            if isinstance(upstream, str):
+                G.add_edge(upstream, task)
+            elif isinstance(upstream, list):
+                [G.add_edge(up, task) for up in upstream]
+
+        # Check if the task exists in the graph
+        if task_name not in G:
+            logger.warning("Task %r not found in dependency graph", task_name)
+            return set()
+
+        # Find all ancestors (upstream tasks) of the given task
+        try:
+            ancestors = nx.ancestors(G, task_name)
+            # Include the task itself
+            preserved_tasks = ancestors | {task_name}
+        except nx.NetworkXError as e:
+            logger.error("Error computing ancestors for %r: %s", task_name, e)
+            preserved_tasks = {task_name}
+
+        logger.info("Tasks to preserve for %r: %s", task_name, preserved_tasks)
+        return preserved_tasks
 
     @staticmethod
     def _filesets_to_remove(scan: "Scan", exclude: set[str]) -> list[str]:
@@ -1101,22 +1207,29 @@ class Clean(RomiTask):
             file_.set_metadata(cleaned_md)
 
     @staticmethod
-    def _clean_orphan_json_files(metadata_dir: Path) -> None:
-        """Remove JSON files that are not ``images.json`` or ``metadata.json``.
+    def _clean_orphan_json_files(metadata_dir: Path, known_fileset: list[str]) -> None:
+        """Remove JSON files related to orphan filesets.
+
+        Orphan filesets are defined as those unknown to the scan `files.json`.
 
         Parameters
         ----------
-        metadata_dir:
-            Path to the ``metadata`` directory of the scan.
+        metadata_dir: pathlib.Path
+            The path to the ``metadata`` directory of the scan.
+        known_fileset: list[str]
+            The list of known fileset, _i.e._ those to keep, resolve to their name with a '.json' extension.
         """
         pattern = str(metadata_dir / "*.json")
+        # List the fileset metadata to remove:
+        json2keep = {"metadata.json"} | {f"{fs}.json" for fs in known_fileset}
         json_files = [
-            f for f in glob.glob(pattern) if Path(f).name not in {"images.json", "metadata.json"}
+            f for f in glob.glob(pattern) if Path(f).name not in json2keep
         ]
 
         if json_files:
             logger.info("Found %d orphan JSON metadata files.", len(json_files))
 
+        # Perform fileset metadata cleanup:
         for file_path in json_files:
             try:
                 Path(file_path).unlink(missing_ok=False)
@@ -1125,21 +1238,27 @@ class Clean(RomiTask):
                 logger.error("Failed to delete JSON file (not found): %s", file_path)
 
     @staticmethod
-    def _clean_orphan_directories(metadata_dir: Path) -> None:
-        """Remove empty metadata sub‑directories that are not the ``images`` folder.
+    def _clean_orphan_directories(metadata_dir: Path, known_fileset: list[str]) -> None:
+        """Remove orphan fileset directories.
+
+        Orphan filesets are defined as those unknown to the scan `files.json`.
 
         Parameters
         ----------
-        metadata_dir:
-            Path to the ``metadata`` directory of the scan.
+        metadata_dir: pathlib.Path
+            The path to the ``metadata`` directory of the scan.
+        known_fileset: list[str]
+            The list of known fileset, _i.e._ those to keep, resolve to their name.
         """
+        # List the fileset directories to remove:
         subdirs = {
                       d for d in os.listdir(metadata_dir) if (metadata_dir / d).is_dir()
-                  } - {"images"}
+                  } - set(known_fileset)
 
         if subdirs:
             logger.info("Found %d orphan metadata directories.", len(subdirs))
 
+        # Perform fileset directories cleanup:
         for subdir in subdirs:
             dir_path = metadata_dir / subdir
             try:
@@ -1180,32 +1299,71 @@ class Clean(RomiTask):
         # - Create the list of metadata to keep (retain) to a set and add the ones defined in `IMAGES_MD`
         metadata_whitelist = self._merge_metadata_keep_list(self.keep_metadata)
 
+        # - Compute the set of filesets to preserve
+        filesets_to_preserve = {"images"}  # Always keep images
+
+        tasks_to_preserve = []
+        if self.keep_task:
+            # Parse the pipeline configuration to get task dependencies
+            task_dependencies = self._parse_pipeline_toml(scan)
+
+            if task_dependencies:
+                # Compute the full hierarchy of tasks to preserve
+                tasks_to_preserve = self._compute_task_hierarchy(
+                    self.keep_task, task_dependencies
+                )
+
+                # Fileset IDs need to be matched to task names as they have specific suffixes
+                task_fs_map = locate_task_filesets(scan, tasks_to_preserve)
+                # Add task-related fileset IDs to the preserve list
+                filesets_to_preserve.update(list(task_fs_map.values()))
+
+                logger.info(
+                    "Preserving task %r and its ancestors: %s",
+                    self.keep_task,
+                    tasks_to_preserve
+                )
+            else:
+                logger.warning(
+                    "Could not parse task dependencies, only keeping %r",
+                    self.keep_task
+                )
+                filesets_to_preserve.add(self.keep_task)
+
         # - Handle the necessity to confirm prior to dataset & metadata cleaning.
         if not self.no_confirm:
-            del_msg = "This will delete all filesets and metadata except for the `images` & 'VirtualPlant' filesets."
+            del_msg = (
+                f"This will delete all filesets except: {filesets_to_preserve} "
+                "and 'VirtualPlant' filesets."
+            )
             logger.warning(del_msg)
             if not self._confirm():
                 logger.info("User aborted the cleaning operation.")
                 return
 
         # - Delete unwanted filesets.
-        filesets_to_remove = self._filesets_to_remove(scan, exclude={"images"})
+        filesets_to_remove = self._filesets_to_remove(scan, exclude=filesets_to_preserve)
         if filesets_to_remove:
             self._delete_filesets(scan, filesets_to_remove)
         else:
-            logger.info("No filesets to delete (only 'images' and VirtualPlant* remain).")
+            logger.info("No filesets to delete (preserved: %s).", filesets_to_preserve)
 
-        # - Clean the metadata of the ``images`` fileset.
-        images_fs = scan.get_fileset("images")
-        if images_fs is None:
-            logger.critical("Could not locate the 'images' fileset in scan %s.", scan.id)
-        else:
-            self._clean_images_metadata(images_fs, metadata_whitelist)
+        # - Clean the metadata of the ``images`` fileset if Colmap task is not preserved.
+        # Colmap is the only task that writes to the 'images' metadata.
+        if 'Colmap' not in tasks_to_preserve:
+            images_fs = scan.get_fileset("images")
+            if images_fs is None:
+                logger.critical("Could not locate the 'images' fileset in scan %s.", scan.id)
+            else:
+                self._clean_images_metadata(images_fs, metadata_whitelist)
 
         # - Clean orphan metadata files and directories.
+        with open(scan.path() / "files.json", "r") as f:
+            json_data = json.load(f)["filesets"]
+            known_fs = [fs['id'] for fs in json_data]
         metadata_dir = Path(scan.path()) / "metadata"
-        self._clean_orphan_json_files(metadata_dir)
-        self._clean_orphan_directories(metadata_dir)
+        self._clean_orphan_json_files(metadata_dir, known_fs)
+        self._clean_orphan_directories(metadata_dir, known_fs)
 
         # - Optionally remove the pipeline backup.
         if not self.keep_pipeline_cfg:
@@ -1213,7 +1371,6 @@ class Clean(RomiTask):
 
         logger.info("Cleaning task finished for scan %r.", scan.id)
         return
-
 
 class RetryTracker(RomiTask):
     """Tracks retry counts for tasks by storing them in a JSON file.

--- a/src/romitask/task.py
+++ b/src/romitask/task.py
@@ -1353,7 +1353,7 @@ class Clean(RomiTask):
         if 'Colmap' not in tasks_to_preserve:
             images_fs = scan.get_fileset("images")
             if images_fs is None:
-                logger.critical("Could not locate the 'images' fileset in scan %s.", scan.id)
+                logger.warning("Could not locate the 'images' fileset in scan %s.", scan.id)
             else:
                 self._clean_images_metadata(images_fs, metadata_whitelist)
 

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -143,6 +143,9 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
     ``default`` keyword (or the first positional argument when ``default`` is not
     explicitly named).
 
+    The function also traverses the inheritance hierarchy and collects attributes
+    from parent classes, with child class attributes overriding parent class attributes.
+
     Parameters
     ----------
     module_path : pathlib.Path or str
@@ -175,12 +178,14 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
       attribute is omitted.
     * The search includes all classes in the module, regardless of inheritance
       hierarchy.
+    * For classes with inheritance, attributes are collected from parent classes
+      first, then overridden by child class attributes. Parent classes may be
+      defined in different modules.
 
     See Also
     --------
     get_class_defaults : Extract defaults from a single class given source code.
-    merge_config_with_defaults : Combine a configuration dictionary with defaults
-        obtained from task classes.
+    merge_config_with_defaults : Combine a configuration dictionary with defaults obtained from task classes.
 
     Examples
     --------
@@ -199,7 +204,7 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
     >>> print(defaults)
     {'Colmap': {'upstream_task': 'ImagesFilesetExists', 'query': {}, 'colmap_exe': 'roboticsmicrofarms/colmap', 'matcher': 'exhaustive', 'use_gpu': True, 'single_camera': True, 'compute_dense': False, 'alignment_max_error': 10, 'align_pcd': True, 'camera_model': 'SIMPLE_RADIAL', 'bounding_box': None, 'cli_args': {}, 'intrinsic_calibration_scan_id': '', 'extrinsic_calibration_scan_id': '', 'use_calibration_camera': True, 'qc_check': True, 'mad_factor': 3.0, 'metrics': ['xy', 'z', 'pan', 'roll'], 'distance_threshold': 3.0, 'fixed_distance_threshold': 1.0, 'angle_threshold': 5.0, 'fixed_angle_threshold': 3.5, 'max_blind_angle': 30.0, 'retry_count': 10, 'retry': 0}}
     """
-    # Resolve ``module_path`` which may be a file system path or a dotted module name.
+    # - Resolve ``module_path`` which may be a file system path or a dotted module name.
     if isinstance(module_path, Path):
         module_file = module_path
     else:
@@ -216,12 +221,12 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
                 raise ValueError(f"Unable to locate module '{module_path}'.")
             module_file = Path(spec.origin)
 
-    # Parse the source file
+    # - Parse the source file
     with open(module_file, 'r') as f:
         source_code = f.read()
     tree = ast.parse(source_code)
 
-    # Build a map of *module‑level* constants (e.g. `{'COLMAP_EXE': "/usr/bin/colmap"}`)
+    # - Build a map of *module‑level* constants (e.g. `{'COLMAP_EXE': "/usr/bin/colmap"}`)
     global_consts: dict[str, Any] = {}
     for node in tree.body:
         if isinstance(node, ast.Assign):
@@ -239,8 +244,8 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
                 if const_val is not None:
                     global_consts[const_name] = const_val
 
-    # Build a map of imported names → (module, original_name)
-    #      Handles both ``import module`` and ``from mod import name as alias``.
+    # - Build a map of imported names → (module, original_name)
+    # Handles both ``import module`` and ``from mod import name as alias``.
     import_map: dict[str, tuple[str, str]] = {}
     for node in tree.body:
         if isinstance(node, ast.Import):
@@ -254,17 +259,17 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
                 asname = alias.asname or alias.name
                 import_map[asname] = (node.module, alias.name)  # ``from module import name``
 
-    # Walk the tree and extract class defaults, passing the globals map
-    all_defaults: dict[str, dict[str, Any]] = {}
+    # - Build a map of class definitions for quick lookup
+    class_map: dict[str, ast.ClassDef] = {}
     for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef):
-            continue
+        if isinstance(node, ast.ClassDef):
+            class_map[node.name] = node
 
-        class_name = node.name
+    # - Helper function to extract class defaults from a single ClassDef node
+    def extract_class_defaults(class_node: ast.ClassDef) -> dict[str, Any]:
         defaults: dict[str, Any] = {}
-
-        for item in node.body:
-            # 1. Plain assignment:  attr = <value>
+        for item in class_node.body:
+            # 1. Plain assignment: "attr = <value>"
             if isinstance(item, ast.Assign):
                 for target in item.targets:
                     if isinstance(target, ast.Name):
@@ -273,20 +278,114 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
                                                              globals_map=global_consts,
                                                              import_map=import_map)
 
-            # 2. Annotated assignment:  attr: type = <value>
+            # 2. Annotated assignment: "attr: type = <value>"
             elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
                 if item.value is not None:
                     attr_name = item.target.id
                     defaults[attr_name] = _extract_value(item.value,
                                                          globals_map=global_consts,
                                                          import_map=import_map)
+        try:
+            defaults.pop('scan_id')
+        except KeyError:
+            pass
+        return defaults
 
-        # Keep only classes that yielded at least one default
+    # - Helper function to resolve base class and get its defaults
+    def get_base_class_defaults(base_node: ast.AST) -> dict[str, Any]:
+        """
+        Given a base class reference in the AST, attempt to load its defaults.
+
+        Returns a dictionary of defaults from the base class, or an empty dict if
+        the base class cannot be resolved.
+        """
+        base_defaults: dict[str, Any] = {}
+
+        # Case 1: Simple name (e.g., class Child(Parent))
+        if isinstance(base_node, ast.Name):
+            base_class_name = base_node.id
+            # Check if it's defined in the same module
+            if base_class_name in class_map:
+                base_defaults = extract_class_defaults(class_map[base_class_name])
+                # Recursively get parent's parent defaults
+                parent_defaults = get_inherited_defaults(class_map[base_class_name])
+                parent_defaults.update(base_defaults)
+                return parent_defaults
+            # Check if it's imported
+            elif base_class_name in import_map:
+                mod_name, orig_name = import_map[base_class_name]
+                try:
+                    # Recursively get all defaults from the imported module
+                    parent_all_defaults = get_all_task_defaults(mod_name)
+                    actual_name = orig_name or base_class_name
+                    if actual_name in parent_all_defaults:
+                        base_defaults = parent_all_defaults[actual_name]
+                except Exception:
+                    pass
+
+        # Case 2: Attribute (e.g., class Child(module.Parent))
+        elif isinstance(base_node, ast.Attribute):
+            # Build the full dotted name
+            parts: list[str] = []
+            cur = base_node
+            while isinstance(cur, ast.Attribute):
+                parts.append(cur.attr)
+                cur = cur.value
+            if isinstance(cur, ast.Name):
+                parts.append(cur.id)
+
+                # Try to resolve the module
+                base_module = parts[-1]
+                if base_module in import_map:
+                    mod_name, _ = import_map[base_module]
+                    class_name = parts[-2] if len(parts) > 1 else None
+                    if class_name:
+                        try:
+                            parent_all_defaults = get_all_task_defaults(mod_name)
+                            if class_name in parent_all_defaults:
+                                base_defaults = parent_all_defaults[class_name]
+                        except Exception:
+                            pass
+
+        return base_defaults
+
+    # - Helper function to get all inherited defaults for a class
+    def get_inherited_defaults(class_node: ast.ClassDef) -> dict[str, Any]:
+        """
+        Recursively collect defaults from all parent classes.
+
+        Returns a dictionary with defaults from all ancestors, with more specific
+        (child) classes overriding more general (parent) classes.
+        """
+        inherited: dict[str, Any] = {}
+
+        # Process base classes in order (left to right in the class definition)
+        for base in class_node.bases:
+            base_defaults = get_base_class_defaults(base)
+            inherited.update(base_defaults)
+
+        return inherited
+
+    # - Walk the tree and extract class defaults, passing the globals & import map
+    all_defaults: dict[str, dict[str, Any]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+
+        class_name = node.name
+
+        # Start with inherited defaults from parent classes
+        defaults = get_inherited_defaults(node)
+
+        # Then add/override with this class's own defaults
+        class_defaults = extract_class_defaults(node)
+        defaults.update(class_defaults)
+
+        # - Keep only classes that yielded at least one default
         if defaults:
             all_defaults[class_name] = defaults
 
     return all_defaults
-
 
 def _load_module_globals(module_name: str) -> dict[str, Any]:
     """

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -128,7 +128,7 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
 
     The function parses the source file at ``module_path`` using the ``ast`` module,
     walks the abstract syntax tree, and collects attributes that can be safely
-    evaluated with :func:`ast.literal_eval`.  In addition to plain assignments
+    evaluated with `ast.literal_eval`.  In addition to plain assignments
     (e.g. ``attr = 10``) and annotated assignments (e.g. ``attr: int = 5``), it now
     recognises *luigi* parameters such as ``luigi.BoolParameter(default=False)`` or
     ``luigi.ListParameter(default=[])`` and extracts the value passed to the
@@ -279,14 +279,64 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
 
 def _load_module_globals(module_name: str) -> dict[str, Any]:
     """
-    Load the source file of *module_name* and return a mapping of its
-    top‑level constant assignments (those that can be evaluated with
-    ``ast.literal_eval`` or simple expressions like os.environ.get()).
-    This is used as a fallback when an imported name cannot be obtained
-    via ``importlib.import_module`` because the attribute is a complex
-    expression defined in the module.
+    Load the source file for *module_name* and return a mapping of its top‑level
+    constant assignments.
+
+    The function parses the module's source code using `ast` and extracts
+    assignments that can be safely evaluated with ``ast.literal_eval`` or simple
+    expressions such as ``os.environ.get``.  It performs two passes:
+
+    1. **First pass** – collect literals and simple annotated values.
+    2. **Second pass** – attempt to evaluate expressions that reference
+       constants discovered in the first pass (e.g. ``CONST_A = 1`` followed by
+       ``CONST_B = CONST_A + 2``).
+
+    This utility is used as a fallback when an imported name cannot be obtained
+    via `importlib.import_module` because the attribute is defined as a
+    complex expression in the module.
+
+    Parameters
+    ----------
+    module_name : str
+        The fully‑qualified name of the module to inspect (e.g. ``'my_pkg.utils'``).
+
+    Returns
+    -------
+    dict[str, Any]
+        A dictionary mapping constant names to their evaluated values.
+        If the module cannot be found, cannot be read, or no evaluable constants are
+        present, an empty dictionary is returned.
+
+    Raises
+    ------
+    None
+        The function never raises; any failure (missing file, parse error,
+        evaluation error) results in an empty mapping being returned.
+
+    Notes
+    -----
+    * Only top‑level assignments are considered; constants defined inside
+      functions or classes are ignored.
+    * Evaluation is deliberately conservative – if a value cannot be safely
+      interpreted, it is skipped rather than executing arbitrary code.
+    * Environment variable lookups via ``os.environ.get`` or ``os.getenv`` are
+      supported and will return the value from the environment (or the provided default).
+
+    Examples
+    --------
+    >>> from romitask.task_defaults import _load_module_globals
+    >>> consts = _load_module_globals('romitask.task')
+    >>> consts.get('IMAGES_MD')
+    ['pose', 'approximate_pose', 'channel', 'shot_id', 'camera']
+    >>> # When the module does not exist, an empty dict is returned
+    >>> _load_module_globals('non.existent.module')
+    {}
     """
-    spec = importlib.util.find_spec(module_name)
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except ModuleNotFoundError:
+        return {}
+
     if spec is None or spec.origin is None:
         return {}
 

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -14,6 +14,8 @@ This module makes it easy to keep configuration files up‑to‑date without man
 - **Bulk processing**: `get_all_task_defaults` scans an entire module and returns a mapping of every class to its defaults.
 - **Configuration merging**: `merge_config_with_defaults` combines a user‑provided dictionary (e.g., loaded from TOML) with the discovered defaults, preserving user overrides.
 - **TOML update helper**: `update_toml_with_defaults` reads a TOML file, merges in defaults, and writes the result back to disk (in‑place or to a new file).
+- **Module‑level constant handling and import mapping**: map top‑level constants defined in the inspected file and map imported symbols (both `import module` and `from module import name`).
+  These maps are used to resolve references such as `COLMAP_EXE` or imported constants, ensuring that default values referencing other modules or constants are correctly evaluated.
 
 ## Usage Examples
 
@@ -26,12 +28,14 @@ This module makes it easy to keep configuration files up‑to‑date without man
 >>> module_path = 'romitask.task'
 >>> # 1. Extract defaults from a task module
 >>> defaults = get_all_task_defaults(module_path)
->>> print(defaults)  # {'Clean': {'upstream_task': None, 'no_confirm': False, ...}, ...}
+>>> print(defaults["Clean"])
+{'upstream_task': None, 'no_confirm': False, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
 >>>
 >>> # 2. Merge with an existing configuration (e.g., loaded from a TOML file)
->>> config = {"Clean": {"no_confirm": True}}  # user‑provided overrides
+>>> config = {"Clean": {"no_confirm": True, "undefined_param": None}}  # user‑provided overrides
 >>> merged = merge_config_with_defaults(config, defaults)
->>> print(merged["Clean"])  # {'upstream_task': None, 'no_confirm': True, ...}
+>>> print(merged["Clean"])  # Note the absence on the undefined parameter 'undefined_param'
+{'upstream_task': None, 'no_confirm': True, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
 >>>
 >>> # 3. Update the configuration from a TOML file
 >>> pipe_cfg = update_toml_with_defaults(Path('configs/geom_pipe_real.toml'))

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -51,7 +51,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-import toml
+import tomlkit
 
 from romitask.modules import MODULES
 
@@ -819,10 +819,10 @@ def update_config_with_defaults(
 
     Examples
     --------
-    >>> import toml
+    >>> import tomlkit
     >>> from pathlib import Path
     >>> from romitask.task_defaults import update_config_with_defaults
-    >>> with open('configs/geom_pipe_real.toml') as f: config = toml.load(f)
+    >>> with open('configs/geom_pipe_real.toml') as f: config = tomlkit.load(f)
     >>> print(config['Clean'])
     {'no_confirm': True}
     >>> updated_config = update_config_with_defaults(config)
@@ -886,6 +886,6 @@ def update_toml_with_defaults(
     """
     # Load existing config
     with open(toml_path, 'r') as f:
-        config = toml.load(f)
+        config = tomlkit.load(f)
 
     return update_config_with_defaults(config, module_mapping)

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -103,6 +103,10 @@ def get_class_defaults(source_code: str, class_name: str) -> dict[str, Any]:
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == class_name:
             for item in node.body:
+                try:
+                    ast.literal_eval(item.value)
+                except (AttributeError, ValueError, TypeError):
+                    continue
                 # Look for simple assignments at class level
                 if isinstance(item, ast.Assign):
                     for target in item.targets:
@@ -204,7 +208,10 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
             module_file = Path(module_path)
         else:
             # Assume it is a Python module name; locate the source file via importlib.
-            spec = importlib.util.find_spec(module_path)
+            try:
+                spec = importlib.util.find_spec(module_path)
+            except ModuleNotFoundError:
+                return {}
             if spec is None or spec.origin is None:
                 raise ValueError(f"Unable to locate module '{module_path}'.")
             module_file = Path(spec.origin)
@@ -338,7 +345,7 @@ def _load_module_globals(module_name: str) -> dict[str, Any]:
     """
     try:
         spec = importlib.util.find_spec(module_name)
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ValueError):
         return {}
 
     if spec is None or spec.origin is None:

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -21,730 +21,148 @@ This module makes it easy to keep configuration files up‑to‑date without man
 
 ```python
 >>> from pathlib import Path
->>> from romitask.task_defaults import get_all_task_defaults
+>>> from romitask.task_defaults import get_task_defaults
 >>> from romitask.task_defaults import merge_config_with_defaults
 >>> from romitask.task_defaults import update_toml_with_defaults
 >>>
 >>> module_path = 'romitask.task'
 >>> # 1. Extract defaults from a task module
->>> defaults = get_all_task_defaults(module_path)
->>> print(defaults["Clean"])
+>>> defaults = get_task_defaults("Clean", module_path)
+>>> print(defaults)
 {'upstream_task': None, 'no_confirm': False, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
 >>>
 >>> # 2. Merge with an existing configuration (e.g., loaded from a TOML file)
 >>> config = {"Clean": {"no_confirm": True, "undefined_param": None}}  # user‑provided overrides
->>> merged = merge_config_with_defaults(config, defaults)
->>> print(merged["Clean"])  # Note the absence on the undefined parameter 'undefined_param'
+>>> merged = merge_config_with_defaults(config["Clean"], defaults)
+>>> print(merged)  # Note the absence on the undefined parameter 'undefined_param'
 {'upstream_task': None, 'no_confirm': True, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
 >>>
 >>> # 3. Update the configuration from a TOML file
->>> pipe_cfg = update_toml_with_defaults(Path('configs/geom_pipe_real.toml'))
+>>> pipe_cfg = update_toml_with_defaults(Path('../configs/geom_pipe_real.toml'))
 >>> print(pipe_cfg['Clean'])
 {'upstream_task': None, 'no_confirm': True, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
 ```
 
 """
 
-import ast
 import importlib.util
-import os
 from pathlib import Path
 from typing import Any
 
 import tomlkit
+from luigi.task_register import Register
 
 from romitask.modules import MODULES
 
 
-def get_class_defaults(source_code: str, class_name: str) -> dict[str, Any]:
+def get_task_defaults(task_name: str, module_path: Path | str) -> dict[str, Any]:
     """
-    Extract default class attributes from a Python source string.
+    Extract default parameter values from a task class in a specified module.
+
+    This function dynamically imports a module, retrieves a task class by name,
+    and extracts its default parameter values.
 
     Parameters
     ----------
-    source_code : str
-        The complete source code of a Python module as a single string.
-    class_name : str
-        Name of the class whose class‑level defaults should be extracted.
+    task_name : str
+        The name of the task class to retrieve from the module. This should be
+        an exact match to the class name as defined in the module.
+    module_path : Path or str
+        The import path to the module containing the task class. Can be provided
+        as a string (e.g., 'package.subpackage.module') or as a Path object.
+        Must be a valid Python module path.
 
     Returns
     -------
     dict[str, Any]
-        Mapping from the attribute name to its default value for the specified class.
-        Only attributes that can be evaluated by `ast.literal_eval` are included;
-        attributes with complex expressions are ignored.
-
-    Notes
-    -----
-    * The function walks the AST of ``source_code`` and looks for ``ast.ClassDef`` nodes matching ``class_name``.
-    * It supports both plain assignments (e.g. ``attr = 10``) and annotated
-      assignments with a value (e.g. ``attr: int = 5``).
-    * Attributes whose values cannot be safely evaluated with
-      ``ast.literal_eval`` (e.g., calls or comprehensions) are silently skipped.
-    * The search stops after the first matching class definition is found.
-
-    Examples
-    --------
-    >>> from romitask.task_defaults import get_class_defaults
-    >>> source = '''
-    ... class Example:
-    ...     count = 42
-    ...     name: str = "test"
-    ...     # Complex expression (ignored)
-    ...     value = [i for i in range(3)]
-    ... '''
-    >>> defaults = get_class_defaults(source, "Example")
-    >>> print(defaults)
-    {'count': 42, 'name': 'test'}
-    """
-    tree = ast.parse(source_code)
-    defaults = {}
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == class_name:
-            for item in node.body:
-                try:
-                    ast.literal_eval(item.value)
-                except (AttributeError, ValueError, TypeError):
-                    continue
-                # Look for simple assignments at class level
-                if isinstance(item, ast.Assign):
-                    for target in item.targets:
-                        if isinstance(target, ast.Name):
-                            attr_name = target.id
-                            # Extract the value
-                            value = ast.literal_eval(item.value)
-                            defaults[attr_name] = value
-                # Handle annotated assignments (e.g., attr: str = "value")
-                elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
-                    if item.value is not None:
-                        attr_name = item.target.id
-                        try:
-                            value = ast.literal_eval(item.value)
-                            defaults[attr_name] = value
-                        except (ValueError, TypeError):
-                            pass
-            break
-
-    return defaults
-
-
-def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
-    """
-    Extract default class attributes from all classes defined in a Python module,
-    including defaults of *luigi* parameter objects.
-
-    The function parses the source file at ``module_path`` using the ``ast`` module,
-    walks the abstract syntax tree, and collects attributes that can be safely
-    evaluated with `ast.literal_eval`.  In addition to plain assignments
-    (e.g. ``attr = 10``) and annotated assignments (e.g. ``attr: int = 5``), it now
-    recognises *luigi* parameters such as ``luigi.BoolParameter(default=False)`` or
-    ``luigi.ListParameter(default=[])`` and extracts the value passed to the
-    ``default`` keyword (or the first positional argument when ``default`` is not
-    explicitly named).
-
-    The function also traverses the inheritance hierarchy and collects attributes
-    from parent classes, with child class attributes overriding parent class attributes.
-
-    Parameters
-    ----------
-    module_path : pathlib.Path or str
-        Path to the Python module file whose classes should be inspected.
-
-    Returns
-    -------
-    dict[str, dict[str, Any]]
-        Mapping from class name to a dictionary of attribute names and their
-        evaluated default values.  Only classes that define at least one
-        evaluable attribute are included in the result.
+        A dictionary mapping parameter names to their default values.
 
     Raises
     ------
-    FileNotFoundError
-        If ``module_path`` does not point to an existing file.
-    PermissionError
-        If the file cannot be read due to insufficient permissions.
+    ModuleNotFoundError
+        If the specified module_path does not exist or cannot be imported.
+    AttributeError
+        If the task_name does not exist as an attribute in the specified module.
+    TypeError
+        If the task class is not a ``luigi.task_register.Register`` instance.
 
     Notes
     -----
-    * The function does **not** execute any code from the target module; it
-      only analyses the static source tree, making it safe for untrusted input.
-    * Attributes with values that cannot be represented by ``ast.literal_eval``
-      (e.g., function calls, list comprehensions, lambda expressions) are
-      skipped without raising an exception, unless they are recognised *luigi*
-      parameter calls.
-    * For *luigi* parameters the parser extracts the ``default`` argument.  If
-      the argument cannot be evaluated (e.g., it is a complex expression), the
-      attribute is omitted.
-    * The search includes all classes in the module, regardless of inheritance
-      hierarchy.
-    * For classes with inheritance, attributes are collected from parent classes
-      first, then overridden by child class attributes. Parent classes may be
-      defined in different modules.
+    The 'scan_id' parameter is explicitly excluded from the results.
+    Special handling is applied to different parameter types:
 
-    See Also
-    --------
-    get_class_defaults : Extract defaults from a single class given source code.
-    merge_config_with_defaults : Combine a configuration dictionary with defaults obtained from task classes.
+    - dictionaries and lists are converted to strings,
+    - type objects are converted to their string names,
 
     Examples
     --------
     >>> from pathlib import Path
-    >>> from romitask.task_defaults import get_all_task_defaults
-    >>> defaults = get_all_task_defaults('romitask.task')
-    >>> print(defaults['Clean'])
-    {'upstream_task': None, 'no_confirm': False, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
-    >>> defaults = get_all_task_defaults(Path('romitask/src/romitask/task.py'))
-    >>> print(defaults['Clean'])
-    {'upstream_task': None, 'no_confirm': False, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
-    >>> defaults = get_all_task_defaults('plant3dvision.tasks.voxel_reconstruction')
+    >>> from romitask.task_defaults import get_task_defaults
+    >>> defaults = get_task_defaults('Undistort', 'plant3dvision.tasks.proc2d')
     >>> print(defaults)
-    {'Voxels': {'upstream_task': 'Masks', 'query': {}, 'camera_metadata': 'colmap_camera', 'voxel_size': 1.0, 'method': 'averaging', 'log': True, 'invert': False, 'labels': [], 'bounding_box': None, 'bounding_box_edit': None}}
-    >>> defaults = get_all_task_defaults('plant3dvision.tasks.colmap')
+    {'query': '{}', 'upstream_task': 'ImagesFilesetExists', 'camera_model_src': 'Colmap', 'camera_model': 'SIMPLE_RADIAL', 'intrinsic_calib_scan_id': '', 'extrinsic_calib_scan_id': '', 'n_workers': -1, 'parallel': True}
+    >>> defaults = get_task_defaults('Clean', 'romitask.task')
     >>> print(defaults)
-    {'Colmap': {'upstream_task': 'ImagesFilesetExists', 'query': {}, 'colmap_exe': 'roboticsmicrofarms/colmap', 'matcher': 'exhaustive', 'use_gpu': True, 'single_camera': True, 'compute_dense': False, 'alignment_max_error': 10, 'align_pcd': True, 'camera_model': 'SIMPLE_RADIAL', 'bounding_box': None, 'cli_args': {}, 'intrinsic_calibration_scan_id': '', 'extrinsic_calibration_scan_id': '', 'use_calibration_camera': True, 'qc_check': True, 'mad_factor': 3.0, 'metrics': ['xy', 'z', 'pan', 'roll'], 'distance_threshold': 3.0, 'fixed_distance_threshold': 1.0, 'angle_threshold': 5.0, 'fixed_angle_threshold': 3.5, 'max_blind_angle': 30.0, 'retry_count': 10, 'retry': 0}}
+    {'query': '{}', 'upstream_task': 'ImagesFilesetExists', 'camera_model_src': 'Colmap', 'camera_model': 'SIMPLE_RADIAL', 'intrinsic_calib_scan_id': '', 'extrinsic_calib_scan_id': '', 'n_workers': -1, 'parallel': True}
     """
-    # - Resolve ``module_path`` which may be a file system path or a dotted module name.
+    # Accept both import‑style strings (e.g. "package.module") and filesystem paths.
     if isinstance(module_path, Path):
-        module_file = module_path
+        module_path = str(module_path)
+    # If the string looks like a filesystem path to a .py file, load it via spec.
+    path_obj = Path(module_path)
+    if path_obj.is_file() and path_obj.suffix == ".py":
+        # Use the stem of the file as a temporary module name.
+        module_name = path_obj.stem
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None or spec.loader is None:  # pragma: no cover
+            raise ModuleNotFoundError(f"Cannot load module from path: {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore[attr-defined]
     else:
-        # ``module_path`` is a string – decide whether it looks like a file path.
-        if os.path.sep in module_path or module_path.endswith('.py'):
-            module_file = Path(module_path)
+        # Dynamically import the module using its import path.
+        module = importlib.import_module(module_path)
+
+    task = getattr(module, task_name)
+
+    if not isinstance(task, Register):
+        raise TypeError(f"Class '{task_name}' is not a Luigi task.'")
+
+    # Extract the default parameter values:
+    defaults = [(p_name, p._default) for p_name, p in task.get_params() if p_name != 'scan_id']
+
+    # Convert default parameter values to desired types:
+    task_defaults = {}
+    for (p_name, p_value) in defaults:
+        if isinstance(p_value, (dict, list)):
+            # Convert dictionaries and lists to strings:
+            task_defaults[p_name] = str(p_value)
+        elif isinstance(p_value, type):
+            # convert type objects to their string names:
+            task_defaults[p_name] = p_value.__name__
         else:
-            # Assume it is a Python module name; locate the source file via importlib.
-            try:
-                spec = importlib.util.find_spec(module_path)
-            except ModuleNotFoundError:
-                return {}
-            if spec is None or spec.origin is None:
-                raise ValueError(f"Unable to locate module '{module_path}'.")
-            module_file = Path(spec.origin)
+            task_defaults[p_name] = p_value
 
-    # - Parse the source file
-    with open(module_file, 'r') as f:
-        source_code = f.read()
-    tree = ast.parse(source_code)
+    # Force 'upstream_task' definition:
+    if 'upstream_task' not in task_defaults:
+        task_defaults['upstream_task'] = None
 
-    # - Build a map of *module‑level* constants (e.g. `{'COLMAP_EXE': "/usr/bin/colmap"}`)
-    global_consts: dict[str, Any] = {}
-    for node in tree.body:
-        if isinstance(node, ast.Assign):
-            # Only handle simple names on the left‑hand side
-            if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
-                const_name = node.targets[0].id
-                const_val = _safe_literal_eval(node.value)
-                if const_val is not None:  # keep only literals we can evaluate
-                    global_consts[const_name] = const_val
-        # also accept annotated assignments (e.g. VAR: str = "value")
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            if node.value is not None:
-                const_name = node.target.id
-                const_val = _safe_literal_eval(node.value)
-                if const_val is not None:
-                    global_consts[const_name] = const_val
-
-    # - Build a map of imported names → (module, original_name)
-    # Handles both ``import module`` and ``from mod import name as alias``.
-    import_map: dict[str, tuple[str, str]] = {}
-    for node in tree.body:
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                asname = alias.asname or alias.name
-                import_map[asname] = (alias.name, None)  # ``module`` is the package itself
-        elif isinstance(node, ast.ImportFrom):
-            if node.module is None:
-                continue  # skip relative imports without a module name
-            for alias in node.names:
-                asname = alias.asname or alias.name
-                import_map[asname] = (node.module, alias.name)  # ``from module import name``
-
-    # - Build a map of class definitions for quick lookup
-    class_map: dict[str, ast.ClassDef] = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef):
-            class_map[node.name] = node
-
-    # - Helper function to extract class defaults from a single ClassDef node
-    def extract_class_defaults(class_node: ast.ClassDef) -> dict[str, Any]:
-        defaults: dict[str, Any] = {}
-        for item in class_node.body:
-            # 1. Plain assignment: "attr = <value>"
-            if isinstance(item, ast.Assign):
-                for target in item.targets:
-                    if isinstance(target, ast.Name):
-                        attr_name = target.id
-                        defaults[attr_name] = _extract_value(item.value,
-                                                             globals_map=global_consts,
-                                                             import_map=import_map)
-
-            # 2. Annotated assignment: "attr: type = <value>"
-            elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
-                if item.value is not None:
-                    attr_name = item.target.id
-                    defaults[attr_name] = _extract_value(item.value,
-                                                         globals_map=global_consts,
-                                                         import_map=import_map)
-        try:
-            defaults.pop('scan_id')
-        except KeyError:
-            pass
-        return defaults
-
-    # - Helper function to resolve base class and get its defaults
-    def get_base_class_defaults(base_node: ast.AST) -> dict[str, Any]:
-        """
-        Given a base class reference in the AST, attempt to load its defaults.
-
-        Returns a dictionary of defaults from the base class, or an empty dict if
-        the base class cannot be resolved.
-        """
-        base_defaults: dict[str, Any] = {}
-
-        # Case 1: Simple name (e.g., class Child(Parent))
-        if isinstance(base_node, ast.Name):
-            base_class_name = base_node.id
-            # Check if it's defined in the same module
-            if base_class_name in class_map:
-                base_defaults = extract_class_defaults(class_map[base_class_name])
-                # Recursively get parent's parent defaults
-                parent_defaults = get_inherited_defaults(class_map[base_class_name])
-                parent_defaults.update(base_defaults)
-                return parent_defaults
-            # Check if it's imported
-            elif base_class_name in import_map:
-                mod_name, orig_name = import_map[base_class_name]
-                try:
-                    # Recursively get all defaults from the imported module
-                    parent_all_defaults = get_all_task_defaults(mod_name)
-                    actual_name = orig_name or base_class_name
-                    if actual_name in parent_all_defaults:
-                        base_defaults = parent_all_defaults[actual_name]
-                except Exception:
-                    pass
-
-        # Case 2: Attribute (e.g., class Child(module.Parent))
-        elif isinstance(base_node, ast.Attribute):
-            # Build the full dotted name
-            parts: list[str] = []
-            cur = base_node
-            while isinstance(cur, ast.Attribute):
-                parts.append(cur.attr)
-                cur = cur.value
-            if isinstance(cur, ast.Name):
-                parts.append(cur.id)
-
-                # Try to resolve the module
-                base_module = parts[-1]
-                if base_module in import_map:
-                    mod_name, _ = import_map[base_module]
-                    class_name = parts[-2] if len(parts) > 1 else None
-                    if class_name:
-                        try:
-                            parent_all_defaults = get_all_task_defaults(mod_name)
-                            if class_name in parent_all_defaults:
-                                base_defaults = parent_all_defaults[class_name]
-                        except Exception:
-                            pass
-
-        return base_defaults
-
-    # - Helper function to get all inherited defaults for a class
-    def get_inherited_defaults(class_node: ast.ClassDef) -> dict[str, Any]:
-        """
-        Recursively collect defaults from all parent classes.
-
-        Returns a dictionary with defaults from all ancestors, with more specific
-        (child) classes overriding more general (parent) classes.
-        """
-        inherited: dict[str, Any] = {}
-
-        # Process base classes in order (left to right in the class definition)
-        for base in class_node.bases:
-            base_defaults = get_base_class_defaults(base)
-            inherited.update(base_defaults)
-
-        return inherited
-
-    # - Walk the tree and extract class defaults, passing the globals & import map
-    all_defaults: dict[str, dict[str, Any]] = {}
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef):
-            continue
-
-        class_name = node.name
-
-        # Start with inherited defaults from parent classes
-        defaults = get_inherited_defaults(node)
-
-        # Then add/override with this class's own defaults
-        class_defaults = extract_class_defaults(node)
-        defaults.update(class_defaults)
-
-        # - Keep only classes that yielded at least one default
-        if defaults:
-            all_defaults[class_name] = defaults
-
-    return all_defaults
-
-def _load_module_globals(module_name: str) -> dict[str, Any]:
-    """
-    Load the source file for *module_name* and return a mapping of its top‑level
-    constant assignments.
-
-    The function parses the module's source code using `ast` and extracts
-    assignments that can be safely evaluated with ``ast.literal_eval`` or simple
-    expressions such as ``os.environ.get``.  It performs two passes:
-
-    1. **First pass** – collect literals and simple annotated values.
-    2. **Second pass** – attempt to evaluate expressions that reference
-       constants discovered in the first pass (e.g. ``CONST_A = 1`` followed by
-       ``CONST_B = CONST_A + 2``).
-
-    This utility is used as a fallback when an imported name cannot be obtained
-    via `importlib.import_module` because the attribute is defined as a
-    complex expression in the module.
-
-    Parameters
-    ----------
-    module_name : str
-        The fully‑qualified name of the module to inspect (e.g. ``'my_pkg.utils'``).
-
-    Returns
-    -------
-    dict[str, Any]
-        A dictionary mapping constant names to their evaluated values.
-        If the module cannot be found, cannot be read, or no evaluable constants are
-        present, an empty dictionary is returned.
-
-    Raises
-    ------
-    None
-        The function never raises; any failure (missing file, parse error,
-        evaluation error) results in an empty mapping being returned.
-
-    Notes
-    -----
-    * Only top‑level assignments are considered; constants defined inside
-      functions or classes are ignored.
-    * Evaluation is deliberately conservative – if a value cannot be safely
-      interpreted, it is skipped rather than executing arbitrary code.
-    * Environment variable lookups via ``os.environ.get`` or ``os.getenv`` are
-      supported and will return the value from the environment (or the provided default).
-
-    Examples
-    --------
-    >>> from romitask.task_defaults import _load_module_globals
-    >>> consts = _load_module_globals('romitask.task')
-    >>> consts.get('IMAGES_MD')
-    ['pose', 'approximate_pose', 'channel', 'shot_id', 'camera']
-    >>> # When the module does not exist, an empty dict is returned
-    >>> _load_module_globals('non.existent.module')
-    {}
-    """
-    try:
-        spec = importlib.util.find_spec(module_name)
-    except (ModuleNotFoundError, ValueError):
-        return {}
-
-    if spec is None or spec.origin is None:
-        return {}
-
-    try:
-        with open(spec.origin, "r") as f:
-            src = f.read()
-    except Exception:
-        return {}
-
-    try:
-        tree = ast.parse(src)
-    except Exception:
-        return {}
-
-    # First pass: collect simple literals
-    consts: dict[str, Any] = {}
-    for node in tree.body:
-        if isinstance(node, ast.Assign):
-            if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
-                name = node.targets[0].id
-                val = _safe_literal_eval(node.value)
-                if val is not None:
-                    consts[name] = val
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            if node.value is not None:
-                name = node.target.id
-                val = _safe_literal_eval(node.value)
-                if val is not None:
-                    consts[name] = val
-
-    # Second pass: try to evaluate expressions that reference already-resolved constants
-    for node in tree.body:
-        if isinstance(node, ast.Assign):
-            if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
-                name = node.targets[0].id
-                if name not in consts:  # Only process if not already resolved
-                    val = _evaluate_expression(node.value, consts)
-                    if val is not None:
-                        consts[name] = val
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            if node.value is not None:
-                name = node.target.id
-                if name not in consts:  # Only process if not already resolved
-                    val = _evaluate_expression(node.value, consts)
-                    if val is not None:
-                        consts[name] = val
-
-    return consts
-
-
-def _evaluate_expression(node: ast.AST, local_consts: dict[str, Any]) -> Any:
-    """
-    Try to evaluate an AST expression node using available constants.
-
-    Handles:
-    - Simple literals
-    - Name references to local_consts
-    - os.environ.get() calls with literal arguments
-
-    Parameters
-    ----------
-    node : ast.AST
-        The expression node to evaluate
-    local_consts : dict[str, Any]
-        Dictionary of already-resolved constant values
-
-    Returns
-    -------
-    Any
-        The evaluated value, or None if evaluation is not possible
-    """
-    # Try simple literal first
-    val = _safe_literal_eval(node)
-    if val is not None:
-        return val
-
-    # Handle Name nodes that reference local constants
-    if isinstance(node, ast.Name):
-        return local_consts.get(node.id)
-
-    # Handle os.environ.get('KEY', 'default') or os.getenv('KEY', 'default')
-    if isinstance(node, ast.Call):
-        # Check if it's os.environ.get() or os.getenv()
-        is_environ_get = False
-        if isinstance(node.func, ast.Attribute):
-            # os.environ.get
-            if (isinstance(node.func.value, ast.Attribute) and
-                    isinstance(node.func.value.value, ast.Name) and
-                    node.func.value.value.id == 'os' and
-                    node.func.value.attr == 'environ' and
-                    node.func.attr == 'get'):
-                is_environ_get = True
-            # os.getenv
-            elif (isinstance(node.func.value, ast.Name) and
-                  node.func.value.id == 'os' and
-                  node.func.attr == 'getenv'):
-                is_environ_get = True
-
-        if is_environ_get and len(node.args) >= 1:
-            # Get the environment variable name
-            key_node = node.args[0]
-            key_val = _safe_literal_eval(key_node)
-            if isinstance(key_val, str):
-                # Get the default value if provided
-                default_val = None
-                if len(node.args) >= 2:
-                    default_val = _safe_literal_eval(node.args[1])
-                elif any(kw.arg == 'default' for kw in node.keywords):
-                    for kw in node.keywords:
-                        if kw.arg == 'default':
-                            default_val = _safe_literal_eval(kw.value)
-                            break
-
-                # Get from environment or use default
-                return os.environ.get(key_val, default_val)
-
-    return None
-
-
-def _extract_value(
-        node: ast.AST, *,
-        globals_map: dict[str, Any] | None = None,
-        import_map: dict[str, tuple[str, str]] | None = None
-) -> Any:
-    """
-    Helper that returns the evaluated value for a given AST node.
-
-    - Tries ``ast.literal_eval`` for simple literals.
-    - Detects ``luigi.*Parameter`` calls and extracts the ``default`` argument.
-    - Returns ``None`` if the value cannot be safely evaluated.
-    - If the node is a ``Name`` (e.g. ``COLMAP_EXE``) we look it up in `globals_map`.
-    - Resolves imported names (e.g. ``COLMAP_EXE`` coming from
-      ``from plant3dvision.colmap import COLMAP_EXE``) by importing the
-      originating module and fetching the attribute.
-    - When the name is not present, we fall back to the identifier string
-
-    Parameters
-    ----------
-    node : ast.AST
-        The AST node representing the right‑hand side of an assignment.
-
-    Returns
-    -------
-    Any
-        The evaluated value, or ``None`` when evaluation is not possible.
-    """
-    # Simple literals (numbers, strings, tuples, lists, dicts, booleans, None)
-    try:
-        return ast.literal_eval(node)
-    except (ValueError, TypeError):
-        pass
-
-    # Name node (local constant or imported)
-    if isinstance(node, ast.Name):
-        # Local constant defined in the same file
-        if globals_map and node.id in globals_map:
-            return globals_map[node.id]  # resolved literal
-
-        # Imported symbol – look it up in ``import_map`` and import the module
-        if import_map and node.id in import_map:
-            mod_name, orig_name = import_map[node.id]
-            # Try a normal import first
-            try:
-                mod = importlib.import_module(mod_name)
-                attr_name = orig_name or node.id
-                value = getattr(mod, attr_name)
-                if isinstance(value, (str, int, float, bool, type(None), dict, list, tuple)):
-                    return value
-                # If it's a class or callable, return its name as a string
-                if isinstance(value, type):  # It's a class
-                    return attr_name
-                # If it's not a plain literal, fall back to static analysis
-                fallback_consts = _load_module_globals(mod_name)
-                if attr_name in fallback_consts:
-                    return fallback_consts[attr_name]
-                # As a last resort, return the identifier string (not None)
-                return attr_name
-            except Exception:
-                # Normal import failed – fall back to static analysis of the module
-                fallback_consts = _load_module_globals(mod_name)
-                attr_name = orig_name or node.id
-                if attr_name in fallback_consts:
-                    return fallback_consts[attr_name]
-                # Could not resolve, return the identifier string
-                return attr_name
-
-        # Not a literal we could evaluate – return the identifier string
-        return node.id
-
-    # Attribute chain (module.Class or module.CONST)
-    if isinstance(node, ast.Attribute):
-        parts: list[str] = []
-        cur = node
-        while isinstance(cur, ast.Attribute):
-            parts.append(cur.attr)
-            cur = cur.value
-        if isinstance(cur, ast.Name):
-            parts.append(cur.id)
-            base_name = parts[-1]
-
-            # Resolve the left‑most name via import map if possible
-            if import_map and base_name in import_map:
-                mod_name, orig_name = import_map[base_name]
-                try:
-                    mod = importlib.import_module(mod_name)
-                    obj = getattr(mod, orig_name or base_name)
-                    # Walk remaining attributes on that object
-                    for attr in reversed(parts[:-1]):
-                        obj = getattr(obj, attr)
-                    # Return literal if possible
-                    if isinstance(obj, (str, int, float, bool, type(None), dict, list, tuple)):
-                        return obj
-                    return ".".join(reversed(parts))
-                except Exception:
-                    # Fallback to static analysis of the module
-                    fallback_consts = _load_module_globals(mod_name)
-                    full_name = ".".join(reversed(parts))
-                    if full_name in fallback_consts:
-                        return fallback_consts[full_name]
-                    # Return dotted name as a last resort
-                    return ".".join(reversed(parts))
-
-            # Fallback – just return the dotted name
-            return ".".join(reversed(parts))
-
-    # Look for luigi parameter calls, e.g. luigi.BoolParameter(default=False)
-    if isinstance(node, ast.Call):
-        # Resolve the called object's name (could be Name or Attribute)
-        func_name = None
-        if isinstance(node.func, ast.Attribute):
-            # e.g. luigi.BoolParameter
-            func_name = node.func.attr
-        elif isinstance(node.func, ast.Name):
-            # e.g. BoolParameter (if imported directly)
-            func_name = node.func.id
-
-        if func_name and func_name.endswith("Parameter"):
-            # Try to find a ``default`` keyword argument
-            for kw in node.keywords:
-                if kw.arg == "default":
-                    # If the default is a simple literal, evaluate it
-                    val = _safe_literal_eval(kw.value)
-                    if val is not None:
-                        return val
-                    # Fallback to name / attribute handling
-                    return _extract_value(kw.value, globals_map=globals_map, import_map=import_map)
-
-            # If no explicit keyword, luigi often uses the first positional arg as default
-            if node.args:
-                # Evaluate first positional arg if possible
-                val = _safe_literal_eval(node.args[0])
-                if val is not None:
-                    return val
-                # Fallback to name / attribute handling
-                return _extract_value(node.args[0], globals_map=globals_map, import_map=import_map)
-
-    # If we reach this point, we couldn't evaluate the expression
-    return None
-
-
-def _safe_literal_eval(node: ast.AST) -> Any:
-    """
-    Wrapper around ``ast.literal_eval`` that silences ``ValueError``/``TypeError``
-    and returns ``None`` for unsupported nodes.
-
-    Parameters
-    ----------
-    node : ast.AST
-        Node to evaluate.
-
-    Returns
-    -------
-    Any
-        Evaluated value or ``None``.
-    """
-    try:
-        return ast.literal_eval(node)
-    except (ValueError, TypeError):
-        return None
+    # Return the dictionary with 'upstream_task' key in first position
+    return {'upstream_task': task_defaults.pop('upstream_task'), **task_defaults}
 
 
 def merge_config_with_defaults(
-        config: dict[str, Any],
-        defaults: dict[str, dict[str, Any]],
+        task_config: dict[str, Any],
+        task_defaults: dict[str, Any],
 ) -> dict[str, Any]:
     """
-    Merge a user‑provided configuration dictionary with default task attributes.
+    Merge a user‑provided task configuration dictionary with default task values.
 
-    The function iterates over each task defined in ``config`` and combines the
-    corresponding entries from ``default`` (if present).
-    Tasks present only in ``config`` are retained unchanged.
-    The merge is shallow: nested dictionaries are not merged recursively.
 
     Parameters
     ----------
-    config : dict[str, Any]
-        Existing configuration dictionary, typically loaded from a TOML file.
-    defaults : dict[str, dict[str, Any]]
+    task_config : dict[str, Any]
+        Existing task configuration dictionary, typically loaded from a TOML file.
+    task_defaults : dict[str, Any]
         Mapping of task names to their default attribute dictionaries as
         produced by `get_all_task_defaults`.
 
@@ -752,34 +170,19 @@ def merge_config_with_defaults(
     -------
     dict[str, Any]
         A new configuration dictionary containing the merged values.
-        The original ``config`` and ``defaults`` inputs are not mutated.
 
     Examples
     --------
     >>> from romitask.task_defaults import merge_config_with_defaults
     >>> config = {"TaskA": {"param": 1}, "ExtraTask": {"value": 42}}
-    >>> defaults = {"TaskA": {"param": 0, "threshold": 0.5}, "TaskB": {"enabled": True}}
-    >>> merged = merge_config_with_defaults(config, defaults)
-    >>> merged["TaskA"]
+    >>> task_defaults = {"param": 0, "threshold": 0.5}  # "TaskA" defaults
+    >>> merged = merge_config_with_defaults(config["TaskA"], task_defaults)
+    >>> merged
     {'param': 1, 'threshold': 0.5}
-    >>> merged["ExtraTask"]
-    {'value': 42}
-    >>> "TaskB" in merged
-    False
     """
-    merged = {}
-
-    # Process each task section
-    for task_name in config:
-        if task_name in defaults:
-            # Merge existing config with defaults, replacing default values with config
-            # eliminating non-existant params from the config if not found in the default
-            merged[task_name] = {param_name: config[task_name].get(param_name, param_value) for param_name, param_value
-                                 in defaults[task_name].items()}
-        else:
-            merged[task_name] = config[task_name]
-
-    return merged
+    # Merge existing config with defaults, replacing default values with config
+    # eliminating non-existent params from the config if not found in the default
+    return {param_name: task_config.get(param_name, param_value) for param_name, param_value in task_defaults.items()}
 
 
 def update_config_with_defaults(
@@ -822,7 +225,7 @@ def update_config_with_defaults(
     >>> import tomlkit
     >>> from pathlib import Path
     >>> from romitask.task_defaults import update_config_with_defaults
-    >>> with open('configs/geom_pipe_real.toml') as f: config = tomlkit.load(f)
+    >>> with open('../configs/geom_pipe_real.toml') as f: config = tomlkit.load(f)
     >>> print(config['Clean'])
     {'no_confirm': True}
     >>> updated_config = update_config_with_defaults(config)
@@ -835,9 +238,9 @@ def update_config_with_defaults(
         if not module_path:
             continue
         # Get defaults from module
-        defaults = get_all_task_defaults(module_path)
+        task_defaults = get_task_defaults(task_name, module_path)
         # Merge config with defaults
-        merged_config[task_name] = merge_config_with_defaults({task_name: task_config}, defaults)[task_name]
+        merged_config[task_name] = merge_config_with_defaults(task_config, task_defaults)
 
     return merged_config
 

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+# Task Default Values
+
+Utility functions for introspecting Python task classes, extracting their default attribute values, and synchronizing those defaults with TOML‑based configuration files.
+This module makes it easy to keep configuration files up‑to‑date without manually copying defaults, and works safely by analyzing source code rather than executing it.
+
+## Key Features
+
+- **Static extraction of class defaults**: Parses a module’s source with the `ast` library to retrieve default values for class‑level attributes and luigi parameters.
+- **Support for plain, annotated, and luigi parameter assignments**: Handles `attr = 10`, `attr: int = 5`, and calls such as `luigi.BoolParameter(default=False)`.
+- **Bulk processing**: `get_all_task_defaults` scans an entire module and returns a mapping of every class to its defaults.
+- **Configuration merging**: `merge_config_with_defaults` combines a user‑provided dictionary (e.g., loaded from TOML) with the discovered defaults, preserving user overrides.
+- **TOML update helper**: `update_toml_with_defaults` reads a TOML file, merges in defaults, and writes the result back to disk (in‑place or to a new file).
+
+## Usage Examples
+
+```python
+>>> from pathlib import Path
+>>> from romitask.task_defaults import get_all_task_defaults
+>>> from romitask.task_defaults import merge_config_with_defaults
+>>> from romitask.task_defaults import update_toml_with_defaults
+>>>
+>>> module_path = 'romitask.task'
+>>> # 1. Extract defaults from a task module
+>>> defaults = get_all_task_defaults(module_path)
+>>> print(defaults)  # {'Clean': {'upstream_task': None, 'no_confirm': False, ...}, ...}
+>>>
+>>> # 2. Merge with an existing configuration (e.g., loaded from a TOML file)
+>>> config = {"Clean": {"no_confirm": True}}  # user‑provided overrides
+>>> merged = merge_config_with_defaults(config, defaults)
+>>> print(merged["Clean"])  # {'upstream_task': None, 'no_confirm': True, ...}
+>>>
+>>> # 3. Update the configuration from a TOML file
+>>> pipe_cfg = update_toml_with_defaults(Path('configs/geom_pipe_real.toml'))
+>>> print(pipe_cfg['Clean'])
+{'upstream_task': None, 'no_confirm': True, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
+```
+
+"""
+
+import ast
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+import toml
+
+from romitask.modules import MODULES
+
+
+def get_class_defaults(source_code: str, class_name: str) -> dict[str, Any]:
+    """
+    Extract default class attributes from a Python source string.
+
+    Parameters
+    ----------
+    source_code : str
+        The complete source code of a Python module as a single string.
+    class_name : str
+        Name of the class whose class‑level defaults should be extracted.
+
+    Returns
+    -------
+    dict[str, Any]
+        Mapping from the attribute name to its default value for the specified class.
+        Only attributes that can be evaluated by `ast.literal_eval` are included;
+        attributes with complex expressions are ignored.
+
+    Notes
+    -----
+    * The function walks the AST of ``source_code`` and looks for ``ast.ClassDef`` nodes matching ``class_name``.
+    * It supports both plain assignments (e.g. ``attr = 10``) and annotated
+      assignments with a value (e.g. ``attr: int = 5``).
+    * Attributes whose values cannot be safely evaluated with
+      ``ast.literal_eval`` (e.g., calls or comprehensions) are silently skipped.
+    * The search stops after the first matching class definition is found.
+
+    Examples
+    --------
+    >>> from romitask.task_defaults import get_class_defaults
+    >>> source = '''
+    ... class Example:
+    ...     count = 42
+    ...     name: str = "test"
+    ...     # Complex expression (ignored)
+    ...     value = [i for i in range(3)]
+    ... '''
+    >>> defaults = get_class_defaults(source, "Example")
+    >>> print(defaults)
+    {'count': 42, 'name': 'test'}
+    """
+    tree = ast.parse(source_code)
+    defaults = {}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                # Look for simple assignments at class level
+                if isinstance(item, ast.Assign):
+                    for target in item.targets:
+                        if isinstance(target, ast.Name):
+                            attr_name = target.id
+                            # Extract the value
+                            value = ast.literal_eval(item.value)
+                            defaults[attr_name] = value
+                # Handle annotated assignments (e.g., attr: str = "value")
+                elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                    if item.value is not None:
+                        attr_name = item.target.id
+                        try:
+                            value = ast.literal_eval(item.value)
+                            defaults[attr_name] = value
+                        except (ValueError, TypeError):
+                            pass
+            break
+
+    return defaults
+
+
+def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
+    """
+    Extract default class attributes from all classes defined in a Python module,
+    including defaults of *luigi* parameter objects.
+
+    The function parses the source file at ``module_path`` using the ``ast`` module,
+    walks the abstract syntax tree, and collects attributes that can be safely
+    evaluated with :func:`ast.literal_eval`.  In addition to plain assignments
+    (e.g. ``attr = 10``) and annotated assignments (e.g. ``attr: int = 5``), it now
+    recognises *luigi* parameters such as ``luigi.BoolParameter(default=False)`` or
+    ``luigi.ListParameter(default=[])`` and extracts the value passed to the
+    ``default`` keyword (or the first positional argument when ``default`` is not
+    explicitly named).
+
+    Parameters
+    ----------
+    module_path : pathlib.Path or str
+        Path to the Python module file whose classes should be inspected.
+
+    Returns
+    -------
+    dict[str, dict[str, Any]]
+        Mapping from class name to a dictionary of attribute names and their
+        evaluated default values.  Only classes that define at least one
+        evaluable attribute are included in the result.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``module_path`` does not point to an existing file.
+    PermissionError
+        If the file cannot be read due to insufficient permissions.
+
+    Notes
+    -----
+    * The function does **not** execute any code from the target module; it
+      only analyses the static source tree, making it safe for untrusted input.
+    * Attributes with values that cannot be represented by ``ast.literal_eval``
+      (e.g., function calls, list comprehensions, lambda expressions) are
+      skipped without raising an exception, unless they are recognised *luigi*
+      parameter calls.
+    * For *luigi* parameters the parser extracts the ``default`` argument.  If
+      the argument cannot be evaluated (e.g., it is a complex expression), the
+      attribute is omitted.
+    * The search includes all classes in the module, regardless of inheritance
+      hierarchy.
+
+    See Also
+    --------
+    get_class_defaults : Extract defaults from a single class given source code.
+    merge_config_with_defaults : Combine a configuration dictionary with defaults
+        obtained from task classes.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> from romitask.task_defaults import get_all_task_defaults
+    >>> defaults = get_all_task_defaults('romitask.task')
+    >>> defaults = get_all_task_defaults(Path('romitask/src/romitask/task.py'))
+    >>> defaults['Clean']
+    {'upstream_task': None,
+     'no_confirm': False,
+     'keep_metadata': [],
+     'keep_pipeline_cfg': True,
+     'keep_task': ''}
+    """
+    # Resolve ``module_path`` which may be a file system path or a dotted module name.
+    if isinstance(module_path, Path):
+        module_file = module_path
+    else:
+        # ``module_path`` is a string – decide whether it looks like a file path.
+        if os.path.sep in module_path or module_path.endswith('.py'):
+            module_file = Path(module_path)
+        else:
+            # Assume it is a Python module name; locate the source file via importlib.
+            spec = importlib.util.find_spec(module_path)
+            if spec is None or spec.origin is None:
+                raise ValueError(f"Unable to locate module '{module_path}'.")
+            module_file = Path(spec.origin)
+
+    with open(module_file, 'r') as f:
+        source_code = f.read()
+
+    tree = ast.parse(source_code)
+    all_defaults: dict[str, dict[str, Any]] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+
+        class_name = node.name
+        defaults: dict[str, Any] = {}
+
+        for item in node.body:
+            # 1. Plain assignment:  attr = <value>
+            if isinstance(item, ast.Assign):
+                for target in item.targets:
+                    if isinstance(target, ast.Name):
+                        attr_name = target.id
+                        defaults[attr_name] = _extract_value(item.value)
+
+            # 2. Annotated assignment:  attr: type = <value>
+            elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                if item.value is not None:
+                    attr_name = item.target.id
+                    defaults[attr_name] = _extract_value(item.value)
+
+        # Keep only classes that yielded at least one default
+        if defaults:
+            all_defaults[class_name] = defaults
+
+    return all_defaults
+
+
+def _extract_value(node: ast.AST) -> Any:
+    """
+    Helper that returns the evaluated value for a given AST node.
+
+    - Tries ``ast.literal_eval`` for simple literals.
+    - Detects ``luigi.*Parameter`` calls and extracts the ``default`` argument.
+    - Returns ``None`` if the value cannot be safely evaluated.
+
+    Parameters
+    ----------
+    node : ast.AST
+        The AST node representing the right‑hand side of an assignment.
+
+    Returns
+    -------
+    Any
+        The evaluated value, or ``None`` when evaluation is not possible.
+    """
+    # Simple literals (numbers, strings, tuples, lists, dicts, booleans, None)
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError):
+        pass
+
+    # Look for luigi parameter calls, e.g. luigi.BoolParameter(default=False)
+    if isinstance(node, ast.Call):
+        # Resolve the called object's name (could be Name or Attribute)
+        func_name = None
+        if isinstance(node.func, ast.Attribute):
+            # e.g. luigi.BoolParameter
+            func_name = node.func.attr
+        elif isinstance(node.func, ast.Name):
+            # e.g. BoolParameter (if imported directly)
+            func_name = node.func.id
+
+        if func_name and func_name.endswith("Parameter"):
+            # Try to find a ``default`` keyword argument
+            for kw in node.keywords:
+                if kw.arg == "default":
+                    return _safe_literal_eval(kw.value)
+
+            # If no explicit keyword, luigi often uses the first positional arg as default
+            if node.args:
+                return _safe_literal_eval(node.args[0])
+
+    # If we reach this point, we couldn't evaluate the expression
+    return None
+
+
+def _safe_literal_eval(node: ast.AST) -> Any:
+    """
+    Wrapper around ``ast.literal_eval`` that silences ``ValueError``/``TypeError``
+    and returns ``None`` for unsupported nodes.
+
+    Parameters
+    ----------
+    node : ast.AST
+        Node to evaluate.
+
+    Returns
+    -------
+    Any
+        Evaluated value or ``None``.
+    """
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError):
+        return None
+
+
+def merge_config_with_defaults(
+        config: dict[str, Any],
+        defaults: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """
+    Merge a user‑provided configuration dictionary with default task attributes.
+
+    The function iterates over each task defined in ``config`` and combines the
+    corresponding entries from ``default`` (if present).
+    Tasks present only in ``config`` are retained unchanged.
+    The merge is shallow: nested dictionaries are not merged recursively.
+
+    Parameters
+    ----------
+    config : dict[str, Any]
+        Existing configuration dictionary, typically loaded from a TOML file.
+    defaults : dict[str, dict[str, Any]]
+        Mapping of task names to their default attribute dictionaries as
+        produced by `get_all_task_defaults`.
+
+    Returns
+    -------
+    dict[str, Any]
+        A new configuration dictionary containing the merged values.
+        The original ``config`` and ``defaults`` inputs are not mutated.
+
+    Examples
+    --------
+    >>> from romitask.task_defaults import merge_config_with_defaults
+    >>> config = {"TaskA": {"param": 1}, "ExtraTask": {"value": 42}}
+    >>> defaults = {"TaskA": {"param": 0, "threshold": 0.5}, "TaskB": {"enabled": True}}
+    >>> merged = merge_config_with_defaults(config, defaults)
+    >>> merged["TaskA"]
+    {'param': 1, 'threshold': 0.5}
+    >>> merged["ExtraTask"]
+    {'value': 42}
+    >>> "TaskB" in merged
+    False
+    """
+    merged = {}
+
+    # Process each task section
+    for task_name in config:
+        if task_name in defaults:
+            # Merge existing config with defaults
+            merged[task_name] = {**defaults[task_name], **config[task_name]}
+        else:
+            merged[task_name] = config[task_name]
+
+    return merged
+
+
+def update_config_with_defaults(
+        config: dict[str, dict[str, Any]],
+        module_mapping: dict[str, str] = MODULES,
+) -> dict[str, dict[str, Any]]:
+    """
+    Update a TOML configuration file with default values from task classes.
+
+    Parameters
+    ----------
+    config : dict[str, dict[str, Any]]
+        Configuration dictionary to update.
+    module_mapping : dict[str, str]
+        Mapping of task names to their module names.
+        Defaults to ``romitask.modules.MODULES``.
+
+    Returns
+    -------
+    dict
+        The merged configuration dictionary.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``toml_path`` does not point to an existing file.
+    toml.TomlDecodeError
+        If the input TOML file cannot be parsed.
+
+    See Also
+    --------
+    romitask.modules.MODULES: the default mapping of task names to their module names.
+
+    Notes
+    -----
+    * The operation is shallow; nested dictionaries are not merged recursively.
+
+    Examples
+    --------
+    >>> import toml
+    >>> from pathlib import Path
+    >>> from romitask.task_defaults import update_config_with_defaults
+    >>> with open('configs/geom_pipe_real.toml') as f: config = toml.load(f)
+    >>> print(config['Clean'])
+    {'no_confirm': True}
+    >>> updated_config = update_config_with_defaults(config)
+    >>> print(updated_config['Clean'])
+    {'upstream_task': None, 'no_confirm': True, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
+    """
+    merged_config: dict[str, Any] = {}
+    for task_name, task_config in config.items():
+        module_path = module_mapping.get(task_name, None)
+        if not module_path:
+            continue
+        # Get defaults from module
+        defaults = get_all_task_defaults(module_path)
+        # Merge config with defaults
+        merged_config[task_name] = merge_config_with_defaults({task_name: task_config}, defaults)[task_name]
+
+    return merged_config
+
+
+def update_toml_with_defaults(
+        toml_path: Path,
+        module_mapping: dict[str, str] = MODULES,
+) -> dict[str, dict[str, Any]]:
+    """
+    Update a TOML configuration file with default values from task classes.
+
+    Parameters
+    ----------
+    toml_path : pathlib.Path
+        Path to the input TOML configuration file to be read.
+    module_mapping : dict[str, str]
+        Mapping of task names to their module names.
+        Defaults to ``romitask.modules.MODULES``.
+
+    Returns
+    -------
+    dict
+        The merged configuration dictionary.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``toml_path`` does not point to an existing file.
+    toml.TomlDecodeError
+        If the input TOML file cannot be parsed.
+
+    See Also
+    --------
+    romitask.modules.MODULES: the default mapping of task names to their module names.
+
+    Notes
+    -----
+    * The operation is shallow; nested dictionaries are not merged recursively.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> from romitask.task_defaults import update_toml_with_defaults
+    >>> pipe_cfg = update_toml_with_defaults(Path('configs/geom_pipe_real.toml'))
+    >>> print(pipe_cfg['Clean'])
+    """
+    # Load existing config
+    with open(toml_path, 'r') as f:
+        config = toml.load(f)
+
+    return update_config_with_defaults(config, module_mapping)

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -274,11 +274,42 @@ def _extract_value(node: ast.AST) -> Any:
             # Try to find a ``default`` keyword argument
             for kw in node.keywords:
                 if kw.arg == "default":
-                    return _safe_literal_eval(kw.value)
+                    # If the default is a simple literal, evaluate it
+                    val = _safe_literal_eval(kw.value)
+                    if val is not None:
+                        return val
+                    # If the default is a Name (e.g. a class reference), return its identifier as a string
+                    if isinstance(kw.value, ast.Name):
+                        return kw.value.id
+                    # If the default is an Attribute (e.g. module.Class), return the dotted name
+                    if isinstance(kw.value, ast.Attribute):
+                        parts = []
+                        cur = kw.value
+                        while isinstance(cur, ast.Attribute):
+                            parts.append(cur.attr)
+                            cur = cur.value
+                        if isinstance(cur, ast.Name):
+                            parts.append(cur.id)
+                        return ".".join(reversed(parts))
 
             # If no explicit keyword, luigi often uses the first positional arg as default
             if node.args:
-                return _safe_literal_eval(node.args[0])
+                # Evaluate first positional arg if possible
+                val = _safe_literal_eval(node.args[0])
+                if val is not None:
+                    return val
+                # Handle Name or Attribute similarly to keyword case
+                if isinstance(node.args[0], ast.Name):
+                    return node.args[0].id
+                if isinstance(node.args[0], ast.Attribute):
+                    parts = []
+                    cur = node.args[0]
+                    while isinstance(cur, ast.Attribute):
+                        parts.append(cur.attr)
+                        cur = cur.value
+                    if isinstance(cur, ast.Name):
+                        parts.append(cur.id)
+                    return ".".join(reversed(parts))
 
     # If we reach this point, we couldn't evaluate the expression
     return None

--- a/src/romitask/task_defaults.py
+++ b/src/romitask/task_defaults.py
@@ -179,13 +179,17 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
     >>> from pathlib import Path
     >>> from romitask.task_defaults import get_all_task_defaults
     >>> defaults = get_all_task_defaults('romitask.task')
+    >>> print(defaults['Clean'])
+    {'upstream_task': None, 'no_confirm': False, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
     >>> defaults = get_all_task_defaults(Path('romitask/src/romitask/task.py'))
-    >>> defaults['Clean']
-    {'upstream_task': None,
-     'no_confirm': False,
-     'keep_metadata': [],
-     'keep_pipeline_cfg': True,
-     'keep_task': ''}
+    >>> print(defaults['Clean'])
+    {'upstream_task': None, 'no_confirm': False, 'keep_metadata': [], 'keep_pipeline_cfg': True, 'keep_task': ''}
+    >>> defaults = get_all_task_defaults('plant3dvision.tasks.voxel_reconstruction')
+    >>> print(defaults)
+    {'Voxels': {'upstream_task': 'Masks', 'query': {}, 'camera_metadata': 'colmap_camera', 'voxel_size': 1.0, 'method': 'averaging', 'log': True, 'invert': False, 'labels': [], 'bounding_box': None, 'bounding_box_edit': None}}
+    >>> defaults = get_all_task_defaults('plant3dvision.tasks.colmap')
+    >>> print(defaults)
+    {'Colmap': {'upstream_task': 'ImagesFilesetExists', 'query': {}, 'colmap_exe': 'roboticsmicrofarms/colmap', 'matcher': 'exhaustive', 'use_gpu': True, 'single_camera': True, 'compute_dense': False, 'alignment_max_error': 10, 'align_pcd': True, 'camera_model': 'SIMPLE_RADIAL', 'bounding_box': None, 'cli_args': {}, 'intrinsic_calibration_scan_id': '', 'extrinsic_calibration_scan_id': '', 'use_calibration_camera': True, 'qc_check': True, 'mad_factor': 3.0, 'metrics': ['xy', 'z', 'pan', 'roll'], 'distance_threshold': 3.0, 'fixed_distance_threshold': 1.0, 'angle_threshold': 5.0, 'fixed_angle_threshold': 3.5, 'max_blind_angle': 30.0, 'retry_count': 10, 'retry': 0}}
     """
     # Resolve ``module_path`` which may be a file system path or a dotted module name.
     if isinstance(module_path, Path):
@@ -201,12 +205,46 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
                 raise ValueError(f"Unable to locate module '{module_path}'.")
             module_file = Path(spec.origin)
 
+    # Parse the source file
     with open(module_file, 'r') as f:
         source_code = f.read()
-
     tree = ast.parse(source_code)
-    all_defaults: dict[str, dict[str, Any]] = {}
 
+    # Build a map of *module‑level* constants (e.g. `{'COLMAP_EXE': "/usr/bin/colmap"}`)
+    global_consts: dict[str, Any] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            # Only handle simple names on the left‑hand side
+            if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+                const_name = node.targets[0].id
+                const_val = _safe_literal_eval(node.value)
+                if const_val is not None:  # keep only literals we can evaluate
+                    global_consts[const_name] = const_val
+        # also accept annotated assignments (e.g. VAR: str = "value")
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.value is not None:
+                const_name = node.target.id
+                const_val = _safe_literal_eval(node.value)
+                if const_val is not None:
+                    global_consts[const_name] = const_val
+
+    # Build a map of imported names → (module, original_name)
+    #      Handles both ``import module`` and ``from mod import name as alias``.
+    import_map: dict[str, tuple[str, str]] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                asname = alias.asname or alias.name
+                import_map[asname] = (alias.name, None)  # ``module`` is the package itself
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                continue  # skip relative imports without a module name
+            for alias in node.names:
+                asname = alias.asname or alias.name
+                import_map[asname] = (node.module, alias.name)  # ``from module import name``
+
+    # Walk the tree and extract class defaults, passing the globals map
+    all_defaults: dict[str, dict[str, Any]] = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
             continue
@@ -220,13 +258,17 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
                 for target in item.targets:
                     if isinstance(target, ast.Name):
                         attr_name = target.id
-                        defaults[attr_name] = _extract_value(item.value)
+                        defaults[attr_name] = _extract_value(item.value,
+                                                             globals_map=global_consts,
+                                                             import_map=import_map)
 
             # 2. Annotated assignment:  attr: type = <value>
             elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
                 if item.value is not None:
                     attr_name = item.target.id
-                    defaults[attr_name] = _extract_value(item.value)
+                    defaults[attr_name] = _extract_value(item.value,
+                                                         globals_map=global_consts,
+                                                         import_map=import_map)
 
         # Keep only classes that yielded at least one default
         if defaults:
@@ -235,13 +277,151 @@ def get_all_task_defaults(module_path: Path | str) -> dict[str, dict[str, Any]]:
     return all_defaults
 
 
-def _extract_value(node: ast.AST) -> Any:
+def _load_module_globals(module_name: str) -> dict[str, Any]:
+    """
+    Load the source file of *module_name* and return a mapping of its
+    top‑level constant assignments (those that can be evaluated with
+    ``ast.literal_eval`` or simple expressions like os.environ.get()).
+    This is used as a fallback when an imported name cannot be obtained
+    via ``importlib.import_module`` because the attribute is a complex
+    expression defined in the module.
+    """
+    spec = importlib.util.find_spec(module_name)
+    if spec is None or spec.origin is None:
+        return {}
+
+    try:
+        with open(spec.origin, "r") as f:
+            src = f.read()
+    except Exception:
+        return {}
+
+    try:
+        tree = ast.parse(src)
+    except Exception:
+        return {}
+
+    # First pass: collect simple literals
+    consts: dict[str, Any] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+                name = node.targets[0].id
+                val = _safe_literal_eval(node.value)
+                if val is not None:
+                    consts[name] = val
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.value is not None:
+                name = node.target.id
+                val = _safe_literal_eval(node.value)
+                if val is not None:
+                    consts[name] = val
+
+    # Second pass: try to evaluate expressions that reference already-resolved constants
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+                name = node.targets[0].id
+                if name not in consts:  # Only process if not already resolved
+                    val = _evaluate_expression(node.value, consts)
+                    if val is not None:
+                        consts[name] = val
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.value is not None:
+                name = node.target.id
+                if name not in consts:  # Only process if not already resolved
+                    val = _evaluate_expression(node.value, consts)
+                    if val is not None:
+                        consts[name] = val
+
+    return consts
+
+
+def _evaluate_expression(node: ast.AST, local_consts: dict[str, Any]) -> Any:
+    """
+    Try to evaluate an AST expression node using available constants.
+
+    Handles:
+    - Simple literals
+    - Name references to local_consts
+    - os.environ.get() calls with literal arguments
+
+    Parameters
+    ----------
+    node : ast.AST
+        The expression node to evaluate
+    local_consts : dict[str, Any]
+        Dictionary of already-resolved constant values
+
+    Returns
+    -------
+    Any
+        The evaluated value, or None if evaluation is not possible
+    """
+    # Try simple literal first
+    val = _safe_literal_eval(node)
+    if val is not None:
+        return val
+
+    # Handle Name nodes that reference local constants
+    if isinstance(node, ast.Name):
+        return local_consts.get(node.id)
+
+    # Handle os.environ.get('KEY', 'default') or os.getenv('KEY', 'default')
+    if isinstance(node, ast.Call):
+        # Check if it's os.environ.get() or os.getenv()
+        is_environ_get = False
+        if isinstance(node.func, ast.Attribute):
+            # os.environ.get
+            if (isinstance(node.func.value, ast.Attribute) and
+                    isinstance(node.func.value.value, ast.Name) and
+                    node.func.value.value.id == 'os' and
+                    node.func.value.attr == 'environ' and
+                    node.func.attr == 'get'):
+                is_environ_get = True
+            # os.getenv
+            elif (isinstance(node.func.value, ast.Name) and
+                  node.func.value.id == 'os' and
+                  node.func.attr == 'getenv'):
+                is_environ_get = True
+
+        if is_environ_get and len(node.args) >= 1:
+            # Get the environment variable name
+            key_node = node.args[0]
+            key_val = _safe_literal_eval(key_node)
+            if isinstance(key_val, str):
+                # Get the default value if provided
+                default_val = None
+                if len(node.args) >= 2:
+                    default_val = _safe_literal_eval(node.args[1])
+                elif any(kw.arg == 'default' for kw in node.keywords):
+                    for kw in node.keywords:
+                        if kw.arg == 'default':
+                            default_val = _safe_literal_eval(kw.value)
+                            break
+
+                # Get from environment or use default
+                return os.environ.get(key_val, default_val)
+
+    return None
+
+
+def _extract_value(
+        node: ast.AST, *,
+        globals_map: dict[str, Any] | None = None,
+        import_map: dict[str, tuple[str, str]] | None = None
+) -> Any:
     """
     Helper that returns the evaluated value for a given AST node.
 
     - Tries ``ast.literal_eval`` for simple literals.
     - Detects ``luigi.*Parameter`` calls and extracts the ``default`` argument.
     - Returns ``None`` if the value cannot be safely evaluated.
+    - If the node is a ``Name`` (e.g. ``COLMAP_EXE``) we look it up in `globals_map`.
+    - Resolves imported names (e.g. ``COLMAP_EXE`` coming from
+      ``from plant3dvision.colmap import COLMAP_EXE``) by importing the
+      originating module and fetching the attribute.
+    - When the name is not present, we fall back to the identifier string
 
     Parameters
     ----------
@@ -258,6 +438,79 @@ def _extract_value(node: ast.AST) -> Any:
         return ast.literal_eval(node)
     except (ValueError, TypeError):
         pass
+
+    # Name node (local constant or imported)
+    if isinstance(node, ast.Name):
+        # Local constant defined in the same file
+        if globals_map and node.id in globals_map:
+            return globals_map[node.id]  # resolved literal
+
+        # Imported symbol – look it up in ``import_map`` and import the module
+        if import_map and node.id in import_map:
+            mod_name, orig_name = import_map[node.id]
+            # Try a normal import first
+            try:
+                mod = importlib.import_module(mod_name)
+                attr_name = orig_name or node.id
+                value = getattr(mod, attr_name)
+                if isinstance(value, (str, int, float, bool, type(None), dict, list, tuple)):
+                    return value
+                # If it's a class or callable, return its name as a string
+                if isinstance(value, type):  # It's a class
+                    return attr_name
+                # If it's not a plain literal, fall back to static analysis
+                fallback_consts = _load_module_globals(mod_name)
+                if attr_name in fallback_consts:
+                    return fallback_consts[attr_name]
+                # As a last resort, return the identifier string (not None)
+                return attr_name
+            except Exception:
+                # Normal import failed – fall back to static analysis of the module
+                fallback_consts = _load_module_globals(mod_name)
+                attr_name = orig_name or node.id
+                if attr_name in fallback_consts:
+                    return fallback_consts[attr_name]
+                # Could not resolve, return the identifier string
+                return attr_name
+
+        # Not a literal we could evaluate – return the identifier string
+        return node.id
+
+    # Attribute chain (module.Class or module.CONST)
+    if isinstance(node, ast.Attribute):
+        parts: list[str] = []
+        cur = node
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.append(cur.id)
+            base_name = parts[-1]
+
+            # Resolve the left‑most name via import map if possible
+            if import_map and base_name in import_map:
+                mod_name, orig_name = import_map[base_name]
+                try:
+                    mod = importlib.import_module(mod_name)
+                    obj = getattr(mod, orig_name or base_name)
+                    # Walk remaining attributes on that object
+                    for attr in reversed(parts[:-1]):
+                        obj = getattr(obj, attr)
+                    # Return literal if possible
+                    if isinstance(obj, (str, int, float, bool, type(None), dict, list, tuple)):
+                        return obj
+                    return ".".join(reversed(parts))
+                except Exception:
+                    # Fallback to static analysis of the module
+                    fallback_consts = _load_module_globals(mod_name)
+                    full_name = ".".join(reversed(parts))
+                    if full_name in fallback_consts:
+                        return fallback_consts[full_name]
+                    # Return dotted name as a last resort
+                    return ".".join(reversed(parts))
+
+            # Fallback – just return the dotted name
+            return ".".join(reversed(parts))
 
     # Look for luigi parameter calls, e.g. luigi.BoolParameter(default=False)
     if isinstance(node, ast.Call):
@@ -278,19 +531,8 @@ def _extract_value(node: ast.AST) -> Any:
                     val = _safe_literal_eval(kw.value)
                     if val is not None:
                         return val
-                    # If the default is a Name (e.g. a class reference), return its identifier as a string
-                    if isinstance(kw.value, ast.Name):
-                        return kw.value.id
-                    # If the default is an Attribute (e.g. module.Class), return the dotted name
-                    if isinstance(kw.value, ast.Attribute):
-                        parts = []
-                        cur = kw.value
-                        while isinstance(cur, ast.Attribute):
-                            parts.append(cur.attr)
-                            cur = cur.value
-                        if isinstance(cur, ast.Name):
-                            parts.append(cur.id)
-                        return ".".join(reversed(parts))
+                    # Fallback to name / attribute handling
+                    return _extract_value(kw.value, globals_map=globals_map, import_map=import_map)
 
             # If no explicit keyword, luigi often uses the first positional arg as default
             if node.args:
@@ -298,18 +540,8 @@ def _extract_value(node: ast.AST) -> Any:
                 val = _safe_literal_eval(node.args[0])
                 if val is not None:
                     return val
-                # Handle Name or Attribute similarly to keyword case
-                if isinstance(node.args[0], ast.Name):
-                    return node.args[0].id
-                if isinstance(node.args[0], ast.Attribute):
-                    parts = []
-                    cur = node.args[0]
-                    while isinstance(cur, ast.Attribute):
-                        parts.append(cur.attr)
-                        cur = cur.value
-                    if isinstance(cur, ast.Name):
-                        parts.append(cur.id)
-                    return ".".join(reversed(parts))
+                # Fallback to name / attribute handling
+                return _extract_value(node.args[0], globals_map=globals_map, import_map=import_map)
 
     # If we reach this point, we couldn't evaluate the expression
     return None
@@ -380,8 +612,10 @@ def merge_config_with_defaults(
     # Process each task section
     for task_name in config:
         if task_name in defaults:
-            # Merge existing config with defaults
-            merged[task_name] = {**defaults[task_name], **config[task_name]}
+            # Merge existing config with defaults, replacing default values with config
+            # eliminating non-existant params from the config if not found in the default
+            merged[task_name] = {param_name: config[task_name].get(param_name, param_value) for param_name, param_value
+                                 in defaults[task_name].items()}
         else:
             merged[task_name] = config[task_name]
 

--- a/src/romitask/utils.py
+++ b/src/romitask/utils.py
@@ -136,6 +136,7 @@ def parse_kbdi(kbdi, default='n'):
     else:
         return valid[kbdi]
 
+
 def ask_confirmation(prompt: str, default: str = "n") -> bool:
     """Prompt the user for a yes/no answer.
 

--- a/tests/test_task_defaults.py
+++ b/tests/test_task_defaults.py
@@ -766,10 +766,10 @@ class TestUpdateTomlWithDefaults(unittest.TestCase):
         self.module_file.write_text(source)
 
         # Write a TOML config file
-        import toml
+        import tomlkit
         config = {"TaskA": {"param1": 20}}
         with open(self.toml_file, "w") as f:
-            toml.dump(config, f)
+            tomlkit.dump(config, f)
 
         # Define module mapping
         module_mapping = {"TaskA": self.module_file}
@@ -792,13 +792,13 @@ class TestUpdateTomlWithDefaults(unittest.TestCase):
 
     def test_invalid_toml_syntax(self):
         """Test that invalid TOML syntax raises TomlDecodeError."""
-        import toml
+        from tomlkit.exceptions import ParseError
 
         # Write invalid TOML content
         self.toml_file.write_text("[[invalid toml")
 
         # Should raise TomlDecodeError
-        with self.assertRaises(toml.TomlDecodeError):
+        with self.assertRaises(ParseError):
             task_defaults.update_toml_with_defaults(self.toml_file)
 
 
@@ -842,13 +842,13 @@ class TestIntegrationScenarios(unittest.TestCase):
         self.module_file.write_text(source)
 
         # Write initial TOML config
-        import toml
+        import tomlkit
         config = {
             "TaskA": {"retry": 5},  # override
             "TaskB": {"count": 20}  # override
         }
         with open(self.toml_file, "w") as f:
-            toml.dump(config, f)
+            tomlkit.dump(config, f)
 
         # Step 1: Extract defaults from module
         defaults = task_defaults.get_all_task_defaults(self.module_file)

--- a/tests/test_task_defaults.py
+++ b/tests/test_task_defaults.py
@@ -12,575 +12,165 @@ This test suite validates all functions in the task_defaults module, including:
 - Configuration merging and TOML file operations
 """
 
-import ast
-import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from shutil import rmtree
 from textwrap import dedent
 
 # Import the module under test
 from romitask import task_defaults
 
 
-class TestGetClassDefaults(unittest.TestCase):
-    """Tests for the get_class_defaults function."""
-
-    def test_simple_class_attribute(self):
-        """Test extraction of a simple class attribute with a literal value."""
-        source = dedent("""
-        class Example:
-            count = 42
-        """)
-        # Extract defaults for the Example class
-        result = task_defaults.get_class_defaults(source, "Example")
-
-        # Should extract the count attribute
-        self.assertEqual(result, {"count": 42})
-
-    def test_annotated_attribute(self):
-        """Test extraction of an annotated class attribute."""
-        source = dedent("""
-        class Example:
-            name: str = "test"
-        """)
-        # Extract defaults for the annotated attribute
-        result = task_defaults.get_class_defaults(source, "Example")
-
-        # Should extract the name attribute with its value
-        self.assertEqual(result, {"name": "test"})
-
-    def test_multiple_attributes(self):
-        """Test extraction of multiple attributes from a single class."""
-        source = dedent("""
-        class Example:
-            count = 42
-            name: str = "test"
-            enabled = True
-        """)
-        # Extract all defaults from the Example class
-        result = task_defaults.get_class_defaults(source, "Example")
-
-        # Should extract all three attributes
-        expected = {"count": 42, "name": "test", "enabled": True}
-        self.assertEqual(result, expected)
-
-    def test_complex_expression_ignored(self):
-        """Test that complex expressions (list comprehensions, etc.) are ignored."""
-        source = dedent("""
-        class Example:
-            count = 42
-            items = [i for i in range(3)]
-        """)
-        # Extract defaults, complex expression should be skipped
-        result = task_defaults.get_class_defaults(source, "Example")
-
-        # Should only extract the simple literal (count), not the comprehension
-        self.assertEqual(result, {"count": 42})
-
-    def test_nonexistent_class(self):
-        """Test that requesting a non-existent class returns an empty dictionary."""
-        source = dedent("""
-        class Example:
-            count = 42
-        """)
-        # Request defaults for a class that doesn't exist
-        result = task_defaults.get_class_defaults(source, "NonExistent")
-
-        # Should return empty dict
-        self.assertEqual(result, {})
-
-    def test_empty_class(self):
-        """Test that a class with no attributes returns an empty dictionary."""
-        source = dedent("""
-        class Example:
-            pass
-        """)
-        # Extract defaults from an empty class
-        result = task_defaults.get_class_defaults(source, "Example")
-
-        # Should return empty dict
-        self.assertEqual(result, {})
-
-    def test_list_and_dict_literals(self):
-        """Test extraction of list and dictionary literal values."""
-        source = dedent("""
-        class Example:
-            items = [1, 2, 3]
-            config = {"key": "value"}
-        """)
-        # Extract complex literal structures
-        result = task_defaults.get_class_defaults(source, "Example")
-
-        # Should extract both list and dict literals
-        expected = {"items": [1, 2, 3], "config": {"key": "value"}}
-        self.assertEqual(result, expected)
-
-    def test_none_value(self):
-        """Test extraction of None as a default value."""
-        source = dedent("""
-        class Example:
-            optional = None
-        """)
-        # Extract None value
-        result = task_defaults.get_class_defaults(source, "Example")
-
-        # Should extract None correctly
-        self.assertEqual(result, {"optional": None})
-
-
-class TestGetAllTaskDefaults(unittest.TestCase):
-    """Tests for the get_all_task_defaults function."""
+class TestGetTaskDefaults(unittest.TestCase):
+    """Tests for the get_task_defaults function."""
 
     def setUp(self):
-        """Create a temporary module file for testing."""
-        # Create a temporary directory and file
+        """Create a temporary package with a test module and patch Register."""
+        # Create a temporary directory that will act as a package root
         self.temp_dir = tempfile.mkdtemp()
-        self.temp_file = Path(self.temp_dir) / "test_module.py"
-
-    def tearDown(self):
-        """Clean up temporary files."""
-        # Remove temporary file and directory
-        if self.temp_file.exists():
-            self.temp_file.unlink()
-        if Path(self.temp_dir).exists():
-            Path(self.temp_dir).rmdir()
-
-    def test_multiple_classes(self):
-        """Test extraction of defaults from multiple classes in a module."""
-        # Write a module with multiple classes
-        source = dedent("""
-        class TaskA:
-            param1 = 10
-            param2 = "test"
-
-        class TaskB:
-            enabled = True
-            count = 5
-        """)
-        self.temp_file.write_text(source)
-
-        # Extract defaults from all classes
-        result = task_defaults.get_all_task_defaults(self.temp_file)
-
-        # Should return defaults for both classes
-        expected = {
-            "TaskA": {"param1": 10, "param2": "test"},
-            "TaskB": {"enabled": True, "count": 5}
-        }
-        self.assertEqual(result, expected)
-
-    def test_module_level_constants(self):
-        """Test that module-level constants are resolved in class attributes."""
-        # Write a module with a top-level constant used in a class
-        source = dedent("""
-        GLOBAL_CONST = 100
-
-        class Task:
-            value = GLOBAL_CONST
-        """)
-        self.temp_file.write_text(source)
-
-        # Extract defaults, should resolve the constant
-        result = task_defaults.get_all_task_defaults(self.temp_file)
-
-        # Should resolve GLOBAL_CONST to 100
-        self.assertEqual(result["Task"]["value"], 100)
-
-    def test_luigi_parameter_keyword_default(self):
-        """Test extraction of default from luigi parameter with keyword argument."""
-        # Write a class with a luigi parameter using keyword default
-        source = dedent("""
-        import luigi
-
-        class Task:
-            enabled = luigi.BoolParameter(default=False)
-            count = luigi.IntParameter(default=42)
-        """)
-        self.temp_file.write_text(source)
-
-        # Extract defaults from luigi parameters
-        result = task_defaults.get_all_task_defaults(self.temp_file)
-
-        # Should extract the default values from luigi parameters
-        expected = {"Task": {"enabled": False, "count": 42}}
-        self.assertEqual(result, expected)
-
-    def test_luigi_parameter_positional_default(self):
-        """Test extraction of default from luigi parameter with positional argument."""
-        # Write a class with luigi parameter using positional default
-        source = dedent("""
-        import luigi
-
-        class Task:
-            name = luigi.Parameter("default_name")
-        """)
-        self.temp_file.write_text(source)
-
-        # Extract defaults from luigi parameter with positional arg
-        result = task_defaults.get_all_task_defaults(self.temp_file)
-
-        # Should extract the first positional argument as default
-        self.assertEqual(result["Task"]["name"], "default_name")
-
-    def test_empty_module(self):
-        """Test that an empty module returns an empty dictionary."""
-        # Write an empty module
-        source = ""
-        self.temp_file.write_text(source)
-
-        # Extract defaults from empty module
-        result = task_defaults.get_all_task_defaults(self.temp_file)
-
-        # Should return empty dict
-        self.assertEqual(result, {})
-
-    def test_class_without_defaults(self):
-        """Test that classes without evaluable defaults are excluded."""
-        # Write a class with only complex expressions
-        source = dedent("""
-        class Task:
-            value = some_function()
-        """)
-        self.temp_file.write_text(source)
-
-        # Extract defaults, class should be excluded
-        result = task_defaults.get_all_task_defaults(self.temp_file)
-
-        # Should return empty dict (no evaluable defaults)
-        self.assertEqual(result['Task']['value'], None)
-
-    def test_annotated_module_constant(self):
-        """Test that annotated module-level constants are recognized."""
-        # Write a module with annotated constant
-        source = dedent("""
-        CONST: int = 50
-
-        class Task:
-            value = CONST
-        """)
-        self.temp_file.write_text(source)
-
-        # Extract defaults, should resolve annotated constant
-        result = task_defaults.get_all_task_defaults(self.temp_file)
-
-        # Should resolve the annotated constant
-        self.assertEqual(result["Task"]["value"], 50)
-
-    def test_nonexistent_file_raises(self):
-        """Test that a non-existent file path raises FileNotFoundError."""
-        # Use a path that doesn't exist
-        nonexistent_path = Path("/nonexistent/path/to/module.py")
-
-        # Should raise FileNotFoundError
-        with self.assertRaises(FileNotFoundError):
-            task_defaults.get_all_task_defaults(nonexistent_path)
-
-    def test_invalid_module_name_raises(self):
-        """Test that an invalid module name raises ValueError."""
-        # Use a module name that cannot be resolved
-        invalid_module = "nonexistent.invalid.module"
-
-        # Should return an empty dictionary
-        result = task_defaults.get_all_task_defaults(invalid_module)
-        self.assertEqual(result, {})
-
-
-class TestLoadModuleGlobals(unittest.TestCase):
-    """Tests for the _load_module_globals helper function."""
-
-    def setUp(self):
-        """Create a temporary module file for testing."""
-        # Create temporary directory and file
-        self.temp_dir = tempfile.mkdtemp()
-        self.temp_file = Path(self.temp_dir) / "test_globals.py"
-
-        # Add temp directory to sys.path so modules can be imported
-        self.original_path = sys.path.copy()
+        self.pkg_path = Path(self.temp_dir) / "tmp_pkg"
+        self.pkg_path.mkdir()
+        # Ensure the package is importable
+        (self.pkg_path / "__init__.py").write_text("")
+        # Insert the temporary directory at the front of sys.path
+        self.original_sys_path = list(sys.path)
         sys.path.insert(0, self.temp_dir)
+        # Helper to write a module file within the temporary package
+        self.module_file = self.pkg_path / "test_mod.py"
 
     def tearDown(self):
-        """Clean up temporary files and restore sys.path."""
-        import sys
-        # Restore original sys.path
-        sys.path = self.original_path
-
-        # Clean up any imported test modules
-        modules_to_remove = [name for name in sys.modules if name.startswith('test_globals')]
-        for module_name in modules_to_remove:
-            del sys.modules[module_name]
-
-        # Remove temporary file and directory
-        if self.temp_file.exists():
-            self.temp_file.unlink()
+        """Clean up the temporary package and restore patched objects."""
+        # Remove the temporary package from sys.path
+        sys.path = self.original_sys_path
+        # Delete temporary files and directories
+        if self.module_file.exists():
+            self.module_file.unlink()
+        if (self.pkg_path / "__init__.py").exists():
+            (self.pkg_path / "__init__.py").unlink()
+        if self.pkg_path.exists():
+            rmtree(self.pkg_path)
         if Path(self.temp_dir).exists():
-            Path(self.temp_dir).rmdir()
-
-    def test_simple_constants(self):
-        """Test extraction of simple top-level constants."""
-        # Write a module with simple constants
-        source = dedent("""
-        CONST_A = 10
-        CONST_B = "test"
-        CONST_C = [1, 2, 3]
-        """)
-        self.temp_file.write_text(source)
-
-        # Load module globals using the module name directly
-        result = task_defaults._load_module_globals("test_globals")
-
-        # Should extract all three constants
-        self.assertIn("CONST_A", result)
-        self.assertIn("CONST_B", result)
-        self.assertIn("CONST_C", result)
-        self.assertEqual(result["CONST_A"], 10)
-        self.assertEqual(result["CONST_B"], "test")
-        self.assertEqual(result["CONST_C"], [1, 2, 3])
-
-    def test_nonexistent_module(self):
-        """Test that a non-existent module returns an empty dictionary."""
-        # Try to load globals from a non-existent module
-        result = task_defaults._load_module_globals("nonexistent.module")
-
-        # Should return empty dict
-        self.assertEqual(result, {})
-
-    def test_os_environ_get(self):
-        """Test that os.environ.get() calls are evaluated correctly."""
-        # Set an environment variable for testing
-        os.environ["TEST_VAR"] = "test_value"
-
-        try:
-            # Write a module that uses os.environ.get
-            source = dedent("""
-            import os
-            CONST = os.environ.get("TEST_VAR", "default")
-            """)
-            self.temp_file.write_text(source)
-
-            # Load module globals
-            result = task_defaults._load_module_globals("test_globals")
-
-            # Should resolve the environment variable
-            self.assertIn("CONST", result)
-            self.assertEqual(result["CONST"], "test_value")
-        finally:
-            # Clean up
-            del os.environ["TEST_VAR"]
-
-    def test_annotated_constants(self):
-        """Test extraction of annotated module-level constants."""
-        # Write a module with annotated constants
-        source = dedent("""
-        CONST_INT: int = 42
-        CONST_STR: str = "hello"
-        CONST_DICT: dict = {"key": "value"}
-        """)
-        self.temp_file.write_text(source)
-
-        # Load module globals
-        result = task_defaults._load_module_globals("test_globals")
-
-        # Should extract all annotated constants
-        self.assertEqual(result["CONST_INT"], 42)
-        self.assertEqual(result["CONST_STR"], "hello")
-        self.assertEqual(result["CONST_DICT"], {"key": "value"})
-
-
-class TestEvaluateExpression(unittest.TestCase):
-    """Tests for the _evaluate_expression helper function."""
-
-    def test_simple_literal(self):
-        """Test evaluation of a simple literal expression."""
-        # Parse a simple literal
-        node = ast.parse("42").body[0].value
-
-        # Evaluate it with empty context
-        result = task_defaults._evaluate_expression(node, {})
-
-        # Should return the literal value
-        self.assertEqual(result, 42)
-
-    def test_name_reference(self):
-        """Test evaluation of a name that references a local constant."""
-        # Parse a name node
-        node = ast.parse("CONST").body[0].value
-
-        # Evaluate with a constant in the context
-        result = task_defaults._evaluate_expression(node, {"CONST": 100})
-
-        # Should resolve to the constant value
-        self.assertEqual(result, 100)
-
-    def test_name_not_in_context(self):
-        """Test evaluation of a name not present in the context returns None."""
-        # Parse a name node
-        node = ast.parse("UNKNOWN").body[0].value
-
-        # Evaluate with empty context
-        result = task_defaults._evaluate_expression(node, {})
-
-        # Should return None
-        self.assertIsNone(result)
-
-    def test_os_environ_get_with_default(self):
-        """Test evaluation of os.environ.get() with a default value."""
-        # Parse an os.environ.get call with default
-        node = ast.parse('os.environ.get("MISSING_VAR", "fallback")').body[0].value
-
-        # Evaluate (variable doesn't exist, should use default)
-        result = task_defaults._evaluate_expression(node, {})
-
-        # Should return the fallback value
-        self.assertEqual(result, "fallback")
-
-    def test_os_getenv_call(self):
-        """Test evaluation of os.getenv() call."""
-        # Set an environment variable
-        os.environ["TEST_GETENV"] = "value"
-
-        # Parse an os.getenv call
-        node = ast.parse('os.getenv("TEST_GETENV")').body[0].value
-
-        try:
-            # Evaluate the call
-            result = task_defaults._evaluate_expression(node, {})
-
-            # Should return the environment variable value
-            self.assertEqual(result, "value")
-        finally:
-            # Clean up
-            del os.environ["TEST_GETENV"]
-
-
-class TestExtractValue(unittest.TestCase):
-    """Tests for the _extract_value helper function."""
-
-    def test_simple_literal(self):
-        """Test extraction of a simple literal value."""
-        # Parse a simple integer literal
-        node = ast.parse("42").body[0].value
-
-        # Extract the value
-        result = task_defaults._extract_value(node)
-
-        # Should return the literal
-        self.assertEqual(result, 42)
-
-    def test_name_in_globals_map(self):
-        """Test extraction of a name that exists in the globals map."""
-        # Parse a name reference
-        node = ast.parse("CONST").body[0].value
-
-        # Extract with globals map
-        result = task_defaults._extract_value(node, globals_map={"CONST": 99})
-
-        # Should resolve to the global constant
-        self.assertEqual(result, 99)
-
-    def test_name_not_in_maps(self):
-        """Test that a name not in any map returns the identifier string."""
-        # Parse a name reference
-        node = ast.parse("UNKNOWN").body[0].value
-
-        # Extract without any maps
-        result = task_defaults._extract_value(node)
-
-        # Should return the name as a string
-        self.assertEqual(result, "UNKNOWN")
-
-    def test_attribute_chain(self):
-        """Test extraction of an attribute chain (e.g., module.Class)."""
-        # Parse an attribute chain
-        node = ast.parse("module.Class").body[0].value
-
-        # Extract the value
-        result = task_defaults._extract_value(node)
-
-        # Should return the dotted name
-        self.assertEqual(result, "module.Class")
-
-    def test_luigi_parameter_with_keyword_default(self):
-        """Test extraction of default from a luigi parameter call with keyword."""
-        # Parse a luigi parameter call with keyword default
-        node = ast.parse("luigi.IntParameter(default=10)").body[0].value
-
-        # Extract the default value
-        result = task_defaults._extract_value(node)
-
-        # Should return the default value
-        self.assertEqual(result, 10)
-
-    def test_luigi_parameter_with_positional_default(self):
-        """Test extraction of default from a luigi parameter call with positional arg."""
-        # Parse a luigi parameter call with positional default
-        node = ast.parse("luigi.Parameter('default_value')").body[0].value
-
-        # Extract the default value
-        result = task_defaults._extract_value(node)
-
-        # Should return the first positional argument
-        self.assertEqual(result, "default_value")
-
-    def test_unsupported_expression(self):
-        """Test that unsupported expressions return None."""
-        # Parse a lambda expression (unsupported)
-        node = ast.parse("lambda x: x + 1").body[0].value
-
-        # Extract the value
-        result = task_defaults._extract_value(node)
-
-        # Should return None
-        self.assertIsNone(result)
-
-
-class TestSafeLiteralEval(unittest.TestCase):
-    """Tests for the _safe_literal_eval helper function."""
-
-    def test_valid_literal(self):
-        """Test evaluation of a valid literal."""
-        # Parse a valid literal
-        node = ast.parse("42").body[0].value
-
-        # Evaluate safely
-        result = task_defaults._safe_literal_eval(node)
-
-        # Should return the value
-        self.assertEqual(result, 42)
-
-    def test_invalid_expression(self):
-        """Test that invalid expressions return None."""
-        # Parse an invalid expression (function call)
-        node = ast.parse("func()").body[0].value
-
-        # Evaluate safely
-        result = task_defaults._safe_literal_eval(node)
-
-        # Should return None
-        self.assertIsNone(result)
-
-    def test_list_literal(self):
-        """Test evaluation of a list literal."""
-        # Parse a list literal
-        node = ast.parse("[1, 2, 3]").body[0].value
-
-        # Evaluate safely
-        result = task_defaults._safe_literal_eval(node)
-
-        # Should return the list
-        self.assertEqual(result, [1, 2, 3])
-
-    def test_dict_literal(self):
-        """Test evaluation of a dictionary literal."""
-        # Parse a dict literal
-        node = ast.parse("{'key': 'value'}").body[0].value
-
-        # Evaluate safely
-        result = task_defaults._safe_literal_eval(node)
-
-        # Should return the dictionary
-        self.assertEqual(result, {"key": "value"})
+            rmtree(Path(self.temp_dir))
+
+    def _write_module(self, source: str):
+        """Write the provided source code to the temporary test module."""
+        self.module_file.write_text(source)
+
+    def test_simple_attribute_extraction(self):
+        """Extract defaults from a plain class with simple attributes."""
+        source = """
+import luigi
+class DummyTask(luigi.Task):
+    param1 = luigi.IntParameter(10)
+    param2 = luigi.Parameter("test")
+
+    @classmethod
+    def get_params(cls):
+        class Param:
+            def __init__(self, default):
+                self._default = default
+        return [("param1", Param(10)), ("param2", Param("test"))]
+"""
+        self._write_module(source)
+
+        # Import the module via its package name
+        defaults = task_defaults.get_task_defaults("DummyTask", self.module_file)
+
+        # Expected defaults (upstream_task is always added)
+        expected = {
+            "upstream_task": None,
+            "param1": 10,
+            "param2": "test",
+        }
+        self.assertEqual(defaults, expected)
+
+    def test_module_constant_resolution(self):
+        """Ensure that module‑level constants are correctly resolved."""
+        source = """
+import luigi
+GLOBAL_CONST = 100
+
+class DummyTask(luigi.Task):
+    value = luigi.IntParameter(GLOBAL_CONST)
+
+    @classmethod
+    def get_params(cls):
+        class Param:
+            def __init__(self, default):
+                self._default = default
+        return [("value", Param(GLOBAL_CONST))]
+"""
+        self._write_module(source)
+
+        defaults = task_defaults.get_task_defaults("DummyTask", self.module_file)
+        expected = {
+            "upstream_task": None,
+            "value": 100,
+        }
+        self.assertEqual(defaults, expected)
+
+    def test_luigi_like_parameter_keyword_default(self):
+        """Simulate a Luigi BoolParameter with a keyword default."""
+        source = """
+import luigi
+class DummyTask(luigi.Task):
+    enabled = None  # placeholder, not used directly
+
+    @classmethod
+    def get_params(cls):
+        class Param:
+            def __init__(self, default):
+                self._default = default
+        return [("enabled", Param(False))]
+"""
+        self._write_module(source)
+
+        defaults = task_defaults.get_task_defaults("DummyTask", self.module_file)
+        expected = {
+            "upstream_task": None,
+            "enabled": False,
+        }
+        self.assertEqual(defaults, expected)
+
+    def test_luigi_like_parameter_positional_default(self):
+        """Simulate a Luigi Parameter where the default is the first positional arg."""
+        source = """
+import luigi
+class DummyTask(luigi.Task):
+    name = None  # placeholder
+
+    @classmethod
+    def get_params(cls):
+        class Param:
+            def __init__(self, default):
+                self._default = default
+        return [("name", Param("default_name"))]
+"""
+        self._write_module(source)
+
+        defaults = task_defaults.get_task_defaults("DummyTask", self.module_file)
+        expected = {
+            "upstream_task": None,
+            "name": "default_name",
+        }
+        self.assertEqual(defaults, expected)
+
+    def test_class_without_params(self):
+        """A task class with no parameters should still return upstream_task."""
+        source = """
+import luigi
+class DummyTask(luigi.Task):
+    @classmethod
+    def get_params(cls):
+        return []
+"""
+        self._write_module(source)
+
+        defaults = task_defaults.get_task_defaults("DummyTask", self.module_file)
+        expected = {"upstream_task": None}
+        self.assertEqual(defaults, expected)
 
 
 class TestMergeConfigWithDefaults(unittest.TestCase):
@@ -593,12 +183,12 @@ class TestMergeConfigWithDefaults(unittest.TestCase):
         defaults = {"TaskA": {"param": 0, "threshold": 0.5}}
 
         # Merge config with defaults
-        result = task_defaults.merge_config_with_defaults(config, defaults)
+        result = task_defaults.merge_config_with_defaults(config['TaskA'], defaults['TaskA'])
 
         # User value should override default
-        self.assertEqual(result["TaskA"]["param"], 1)
+        self.assertEqual(result["param"], 1)
         # Default value should be added
-        self.assertEqual(result["TaskA"]["threshold"], 0.5)
+        self.assertEqual(result["threshold"], 0.5)
 
     def test_merge_adds_missing_defaults(self):
         """Test that missing parameters are added from defaults."""
@@ -607,23 +197,11 @@ class TestMergeConfigWithDefaults(unittest.TestCase):
         defaults = {"TaskA": {"param": 0, "threshold": 0.5, "enabled": True}}
 
         # Merge config with defaults
-        result = task_defaults.merge_config_with_defaults(config, defaults)
+        result = task_defaults.merge_config_with_defaults(config['TaskA'], defaults['TaskA'])
 
         # All default params should be present
         expected = {"param": 1, "threshold": 0.5, "enabled": True}
-        self.assertEqual(result["TaskA"], expected)
-
-    def test_task_not_in_defaults(self):
-        """Test that tasks not in defaults are retained unchanged."""
-        # Define config with a task not in defaults
-        config = {"ExtraTask": {"value": 42}}
-        defaults = {"TaskA": {"param": 0}}
-
-        # Merge config with defaults
-        result = task_defaults.merge_config_with_defaults(config, defaults)
-
-        # ExtraTask should be retained as-is
-        self.assertEqual(result["ExtraTask"], {"value": 42})
+        self.assertEqual(result, expected)
 
     def test_undefined_param_in_config_removed(self):
         """Test that parameters in config but not in defaults are removed."""
@@ -632,37 +210,35 @@ class TestMergeConfigWithDefaults(unittest.TestCase):
         defaults = {"TaskA": {"param": 0, "threshold": 0.5}}
 
         # Merge config with defaults
-        result = task_defaults.merge_config_with_defaults(config, defaults)
+        result = task_defaults.merge_config_with_defaults(config['TaskA'], defaults['TaskA'])
 
         # undefined_param should not be in the result
-        self.assertNotIn("undefined_param", result["TaskA"])
+        self.assertNotIn("undefined_param", result)
         # Only valid params should be present
         expected = {"param": 1, "threshold": 0.5}
-        self.assertEqual(result["TaskA"], expected)
+        self.assertEqual(result, expected)
 
     def test_empty_config(self):
         """Test merging with an empty config dictionary."""
         # Define empty config
-        config = {}
         defaults = {"TaskA": {"param": 0}}
 
         # Merge empty config with defaults
-        result = task_defaults.merge_config_with_defaults(config, defaults)
+        result = task_defaults.merge_config_with_defaults({}, defaults['TaskA'])
 
         # Result should be empty
-        self.assertEqual(result, {})
+        self.assertEqual(result, {"param": 0})
 
     def test_empty_defaults(self):
         """Test merging with empty defaults dictionary."""
         # Define config with empty defaults
         config = {"TaskA": {"param": 1}}
-        defaults = {}
 
         # Merge config with empty defaults
-        result = task_defaults.merge_config_with_defaults(config, defaults)
+        result = task_defaults.merge_config_with_defaults(config['TaskA'], {})
 
         # Config should be retained as-is
-        self.assertEqual(result["TaskA"], {"param": 1})
+        self.assertEqual(result, {})
 
 
 class TestUpdateConfigWithDefaults(unittest.TestCase):
@@ -683,22 +259,24 @@ class TestUpdateConfigWithDefaults(unittest.TestCase):
         if self.module_b_file.exists():
             self.module_b_file.unlink()
         if Path(self.temp_dir).exists():
-            Path(self.temp_dir).rmdir()
+            rmtree(self.temp_dir)
 
     def test_update_with_module_mapping(self):
         """Test updating config with a custom module mapping."""
         # Write module A with TaskA
         source_a = dedent("""
-        class TaskA:
-            param1 = 10
-            param2 = "default"
+        import luigi
+        class TaskA(luigi.Task):
+            param1 = luigi.IntParameter(10)
+            param2 = luigi.Parameter("default")
         """)
         self.module_a_file.write_text(source_a)
 
         # Write module B with TaskB
         source_b = dedent("""
-        class TaskB:
-            enabled = False
+        import luigi
+        class TaskB(luigi.Task):
+            enabled = luigi.BoolParameter(False)
         """)
         self.module_b_file.write_text(source_b)
 
@@ -753,15 +331,16 @@ class TestUpdateTomlWithDefaults(unittest.TestCase):
         if self.module_file.exists():
             self.module_file.unlink()
         if Path(self.temp_dir).exists():
-            Path(self.temp_dir).rmdir()
+            rmtree(self.temp_dir)
 
     def test_update_toml_file(self):
         """Test updating a TOML file with defaults from a module."""
         # Write a module with a task
         source = dedent("""
-        class TaskA:
-            param1 = 10
-            param2 = "default"
+        import luigi
+        class TaskA(luigi.Task):
+            param1 = luigi.IntParameter(10)
+            param2 = luigi.Parameter("default")
         """)
         self.module_file.write_text(source)
 
@@ -800,126 +379,6 @@ class TestUpdateTomlWithDefaults(unittest.TestCase):
         # Should raise TomlDecodeError
         with self.assertRaises(ParseError):
             task_defaults.update_toml_with_defaults(self.toml_file)
-
-
-class TestIntegrationScenarios(unittest.TestCase):
-    """Integration tests for complete workflows."""
-
-    def setUp(self):
-        """Create temporary files for integration testing."""
-        # Create temporary directory and files
-        self.temp_dir = tempfile.mkdtemp()
-        self.module_file = Path(self.temp_dir) / "tasks.py"
-        self.toml_file = Path(self.temp_dir) / "config.toml"
-
-    def tearDown(self):
-        """Clean up temporary files."""
-        # Remove temporary files and directory
-        if self.module_file.exists():
-            self.module_file.unlink()
-        if self.toml_file.exists():
-            self.toml_file.unlink()
-        if Path(self.temp_dir).exists():
-            Path(self.temp_dir).rmdir()
-
-    def test_full_workflow_extract_merge_update(self):
-        """Test the complete workflow: extract defaults, merge with config, update TOML."""
-        # Write a module with multiple tasks
-        source = dedent("""
-        import luigi
-
-        GLOBAL_TIMEOUT = 300
-
-        class TaskA:
-            timeout = GLOBAL_TIMEOUT
-            retry = luigi.IntParameter(default=3)
-            enabled = True
-
-        class TaskB:
-            count: int = 10
-            name = "task_b"
-        """)
-        self.module_file.write_text(source)
-
-        # Write initial TOML config
-        import tomlkit
-        config = {
-            "TaskA": {"retry": 5},  # override
-            "TaskB": {"count": 20}  # override
-        }
-        with open(self.toml_file, "w") as f:
-            tomlkit.dump(config, f)
-
-        # Step 1: Extract defaults from module
-        defaults = task_defaults.get_all_task_defaults(self.module_file)
-
-        # Verify extracted defaults
-        self.assertEqual(defaults["TaskA"]["timeout"], 300)
-        self.assertEqual(defaults["TaskA"]["retry"], 3)
-        self.assertEqual(defaults["TaskB"]["count"], 10)
-
-        # Step 2: Merge config with defaults
-        merged = task_defaults.merge_config_with_defaults(config, defaults)
-
-        # Verify merged config
-        self.assertEqual(merged["TaskA"]["retry"], 5)  # overridden
-        self.assertEqual(merged["TaskA"]["timeout"], 300)  # added
-        self.assertEqual(merged["TaskB"]["count"], 20)  # overridden
-        self.assertEqual(merged["TaskB"]["name"], "task_b")  # added
-
-        # Step 3: Update TOML with defaults
-        module_mapping = {"TaskA": self.module_file, "TaskB": self.module_file}
-        result = task_defaults.update_toml_with_defaults(self.toml_file, module_mapping)
-
-        # Verify final result
-        self.assertEqual(result["TaskA"]["retry"], 5)
-        self.assertEqual(result["TaskA"]["timeout"], 300)
-        self.assertEqual(result["TaskB"]["count"], 20)
-        self.assertEqual(result["TaskB"]["name"], "task_b")
-
-    def test_complex_import_resolution(self):
-        """Test handling of imported constants and symbols."""
-        # Write a module that imports and uses external symbols
-        source = dedent("""
-        from pathlib import Path
-
-        BASE_DIR = Path("/tmp")
-
-        class Task:
-            output_dir = BASE_DIR
-        """)
-        self.module_file.write_text(source)
-
-        # Extract defaults (should handle the import)
-        defaults = task_defaults.get_all_task_defaults(self.module_file)
-
-        # Verify that BASE_DIR was resolved
-        # Since it references Path("/tmp"), it should be converted to string or Path
-        self.assertIn("output_dir", defaults["Task"])
-
-    def test_nested_dict_and_list_defaults(self):
-        """Test extraction and merging of nested dictionaries and lists."""
-        # Write a module with nested structures
-        source = dedent("""
-        class Task:
-            config = {"nested": {"key": "value"}}
-            items = [1, [2, 3], 4]
-        """)
-        self.module_file.write_text(source)
-
-        # Extract defaults
-        defaults = task_defaults.get_all_task_defaults(self.module_file)
-
-        # Verify nested structures are preserved
-        self.assertEqual(defaults["Task"]["config"], {"nested": {"key": "value"}})
-        self.assertEqual(defaults["Task"]["items"], [1, [2, 3], 4])
-
-        # Test merging with overrides
-        config = {"Task": {"config": {"nested": {"key": "override"}}}}
-        merged = task_defaults.merge_config_with_defaults(config, defaults)
-
-        # Note: merge is shallow, so nested dict is replaced entirely
-        self.assertEqual(merged["Task"]["config"], {"nested": {"key": "override"}})
 
 
 if __name__ == "__main__":

--- a/tests/test_task_defaults.py
+++ b/tests/test_task_defaults.py
@@ -1,0 +1,926 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for the task_defaults module.
+
+This test suite validates all functions in the task_defaults module, including:
+- Static extraction of class defaults from Python source code
+- Luigi parameter handling
+- Module-level constant resolution
+- Import mapping and resolution
+- Configuration merging and TOML file operations
+"""
+
+import ast
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from textwrap import dedent
+
+# Import the module under test
+from romitask import task_defaults
+
+
+class TestGetClassDefaults(unittest.TestCase):
+    """Tests for the get_class_defaults function."""
+
+    def test_simple_class_attribute(self):
+        """Test extraction of a simple class attribute with a literal value."""
+        source = dedent("""
+        class Example:
+            count = 42
+        """)
+        # Extract defaults for the Example class
+        result = task_defaults.get_class_defaults(source, "Example")
+
+        # Should extract the count attribute
+        self.assertEqual(result, {"count": 42})
+
+    def test_annotated_attribute(self):
+        """Test extraction of an annotated class attribute."""
+        source = dedent("""
+        class Example:
+            name: str = "test"
+        """)
+        # Extract defaults for the annotated attribute
+        result = task_defaults.get_class_defaults(source, "Example")
+
+        # Should extract the name attribute with its value
+        self.assertEqual(result, {"name": "test"})
+
+    def test_multiple_attributes(self):
+        """Test extraction of multiple attributes from a single class."""
+        source = dedent("""
+        class Example:
+            count = 42
+            name: str = "test"
+            enabled = True
+        """)
+        # Extract all defaults from the Example class
+        result = task_defaults.get_class_defaults(source, "Example")
+
+        # Should extract all three attributes
+        expected = {"count": 42, "name": "test", "enabled": True}
+        self.assertEqual(result, expected)
+
+    def test_complex_expression_ignored(self):
+        """Test that complex expressions (list comprehensions, etc.) are ignored."""
+        source = dedent("""
+        class Example:
+            count = 42
+            items = [i for i in range(3)]
+        """)
+        # Extract defaults, complex expression should be skipped
+        result = task_defaults.get_class_defaults(source, "Example")
+
+        # Should only extract the simple literal (count), not the comprehension
+        self.assertEqual(result, {"count": 42})
+
+    def test_nonexistent_class(self):
+        """Test that requesting a non-existent class returns an empty dictionary."""
+        source = dedent("""
+        class Example:
+            count = 42
+        """)
+        # Request defaults for a class that doesn't exist
+        result = task_defaults.get_class_defaults(source, "NonExistent")
+
+        # Should return empty dict
+        self.assertEqual(result, {})
+
+    def test_empty_class(self):
+        """Test that a class with no attributes returns an empty dictionary."""
+        source = dedent("""
+        class Example:
+            pass
+        """)
+        # Extract defaults from an empty class
+        result = task_defaults.get_class_defaults(source, "Example")
+
+        # Should return empty dict
+        self.assertEqual(result, {})
+
+    def test_list_and_dict_literals(self):
+        """Test extraction of list and dictionary literal values."""
+        source = dedent("""
+        class Example:
+            items = [1, 2, 3]
+            config = {"key": "value"}
+        """)
+        # Extract complex literal structures
+        result = task_defaults.get_class_defaults(source, "Example")
+
+        # Should extract both list and dict literals
+        expected = {"items": [1, 2, 3], "config": {"key": "value"}}
+        self.assertEqual(result, expected)
+
+    def test_none_value(self):
+        """Test extraction of None as a default value."""
+        source = dedent("""
+        class Example:
+            optional = None
+        """)
+        # Extract None value
+        result = task_defaults.get_class_defaults(source, "Example")
+
+        # Should extract None correctly
+        self.assertEqual(result, {"optional": None})
+
+
+class TestGetAllTaskDefaults(unittest.TestCase):
+    """Tests for the get_all_task_defaults function."""
+
+    def setUp(self):
+        """Create a temporary module file for testing."""
+        # Create a temporary directory and file
+        self.temp_dir = tempfile.mkdtemp()
+        self.temp_file = Path(self.temp_dir) / "test_module.py"
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        # Remove temporary file and directory
+        if self.temp_file.exists():
+            self.temp_file.unlink()
+        if Path(self.temp_dir).exists():
+            Path(self.temp_dir).rmdir()
+
+    def test_multiple_classes(self):
+        """Test extraction of defaults from multiple classes in a module."""
+        # Write a module with multiple classes
+        source = dedent("""
+        class TaskA:
+            param1 = 10
+            param2 = "test"
+
+        class TaskB:
+            enabled = True
+            count = 5
+        """)
+        self.temp_file.write_text(source)
+
+        # Extract defaults from all classes
+        result = task_defaults.get_all_task_defaults(self.temp_file)
+
+        # Should return defaults for both classes
+        expected = {
+            "TaskA": {"param1": 10, "param2": "test"},
+            "TaskB": {"enabled": True, "count": 5}
+        }
+        self.assertEqual(result, expected)
+
+    def test_module_level_constants(self):
+        """Test that module-level constants are resolved in class attributes."""
+        # Write a module with a top-level constant used in a class
+        source = dedent("""
+        GLOBAL_CONST = 100
+
+        class Task:
+            value = GLOBAL_CONST
+        """)
+        self.temp_file.write_text(source)
+
+        # Extract defaults, should resolve the constant
+        result = task_defaults.get_all_task_defaults(self.temp_file)
+
+        # Should resolve GLOBAL_CONST to 100
+        self.assertEqual(result["Task"]["value"], 100)
+
+    def test_luigi_parameter_keyword_default(self):
+        """Test extraction of default from luigi parameter with keyword argument."""
+        # Write a class with a luigi parameter using keyword default
+        source = dedent("""
+        import luigi
+
+        class Task:
+            enabled = luigi.BoolParameter(default=False)
+            count = luigi.IntParameter(default=42)
+        """)
+        self.temp_file.write_text(source)
+
+        # Extract defaults from luigi parameters
+        result = task_defaults.get_all_task_defaults(self.temp_file)
+
+        # Should extract the default values from luigi parameters
+        expected = {"Task": {"enabled": False, "count": 42}}
+        self.assertEqual(result, expected)
+
+    def test_luigi_parameter_positional_default(self):
+        """Test extraction of default from luigi parameter with positional argument."""
+        # Write a class with luigi parameter using positional default
+        source = dedent("""
+        import luigi
+
+        class Task:
+            name = luigi.Parameter("default_name")
+        """)
+        self.temp_file.write_text(source)
+
+        # Extract defaults from luigi parameter with positional arg
+        result = task_defaults.get_all_task_defaults(self.temp_file)
+
+        # Should extract the first positional argument as default
+        self.assertEqual(result["Task"]["name"], "default_name")
+
+    def test_empty_module(self):
+        """Test that an empty module returns an empty dictionary."""
+        # Write an empty module
+        source = ""
+        self.temp_file.write_text(source)
+
+        # Extract defaults from empty module
+        result = task_defaults.get_all_task_defaults(self.temp_file)
+
+        # Should return empty dict
+        self.assertEqual(result, {})
+
+    def test_class_without_defaults(self):
+        """Test that classes without evaluable defaults are excluded."""
+        # Write a class with only complex expressions
+        source = dedent("""
+        class Task:
+            value = some_function()
+        """)
+        self.temp_file.write_text(source)
+
+        # Extract defaults, class should be excluded
+        result = task_defaults.get_all_task_defaults(self.temp_file)
+
+        # Should return empty dict (no evaluable defaults)
+        self.assertEqual(result['Task']['value'], None)
+
+    def test_annotated_module_constant(self):
+        """Test that annotated module-level constants are recognized."""
+        # Write a module with annotated constant
+        source = dedent("""
+        CONST: int = 50
+
+        class Task:
+            value = CONST
+        """)
+        self.temp_file.write_text(source)
+
+        # Extract defaults, should resolve annotated constant
+        result = task_defaults.get_all_task_defaults(self.temp_file)
+
+        # Should resolve the annotated constant
+        self.assertEqual(result["Task"]["value"], 50)
+
+    def test_nonexistent_file_raises(self):
+        """Test that a non-existent file path raises FileNotFoundError."""
+        # Use a path that doesn't exist
+        nonexistent_path = Path("/nonexistent/path/to/module.py")
+
+        # Should raise FileNotFoundError
+        with self.assertRaises(FileNotFoundError):
+            task_defaults.get_all_task_defaults(nonexistent_path)
+
+    def test_invalid_module_name_raises(self):
+        """Test that an invalid module name raises ValueError."""
+        # Use a module name that cannot be resolved
+        invalid_module = "nonexistent.invalid.module"
+
+        # Should return an empty dictionary
+        result = task_defaults.get_all_task_defaults(invalid_module)
+        self.assertEqual(result, {})
+
+
+class TestLoadModuleGlobals(unittest.TestCase):
+    """Tests for the _load_module_globals helper function."""
+
+    def setUp(self):
+        """Create a temporary module file for testing."""
+        # Create temporary directory and file
+        self.temp_dir = tempfile.mkdtemp()
+        self.temp_file = Path(self.temp_dir) / "test_globals.py"
+
+        # Add temp directory to sys.path so modules can be imported
+        self.original_path = sys.path.copy()
+        sys.path.insert(0, self.temp_dir)
+
+    def tearDown(self):
+        """Clean up temporary files and restore sys.path."""
+        import sys
+        # Restore original sys.path
+        sys.path = self.original_path
+
+        # Clean up any imported test modules
+        modules_to_remove = [name for name in sys.modules if name.startswith('test_globals')]
+        for module_name in modules_to_remove:
+            del sys.modules[module_name]
+
+        # Remove temporary file and directory
+        if self.temp_file.exists():
+            self.temp_file.unlink()
+        if Path(self.temp_dir).exists():
+            Path(self.temp_dir).rmdir()
+
+    def test_simple_constants(self):
+        """Test extraction of simple top-level constants."""
+        # Write a module with simple constants
+        source = dedent("""
+        CONST_A = 10
+        CONST_B = "test"
+        CONST_C = [1, 2, 3]
+        """)
+        self.temp_file.write_text(source)
+
+        # Load module globals using the module name directly
+        result = task_defaults._load_module_globals("test_globals")
+
+        # Should extract all three constants
+        self.assertIn("CONST_A", result)
+        self.assertIn("CONST_B", result)
+        self.assertIn("CONST_C", result)
+        self.assertEqual(result["CONST_A"], 10)
+        self.assertEqual(result["CONST_B"], "test")
+        self.assertEqual(result["CONST_C"], [1, 2, 3])
+
+    def test_nonexistent_module(self):
+        """Test that a non-existent module returns an empty dictionary."""
+        # Try to load globals from a non-existent module
+        result = task_defaults._load_module_globals("nonexistent.module")
+
+        # Should return empty dict
+        self.assertEqual(result, {})
+
+    def test_os_environ_get(self):
+        """Test that os.environ.get() calls are evaluated correctly."""
+        # Set an environment variable for testing
+        os.environ["TEST_VAR"] = "test_value"
+
+        try:
+            # Write a module that uses os.environ.get
+            source = dedent("""
+            import os
+            CONST = os.environ.get("TEST_VAR", "default")
+            """)
+            self.temp_file.write_text(source)
+
+            # Load module globals
+            result = task_defaults._load_module_globals("test_globals")
+
+            # Should resolve the environment variable
+            self.assertIn("CONST", result)
+            self.assertEqual(result["CONST"], "test_value")
+        finally:
+            # Clean up
+            del os.environ["TEST_VAR"]
+
+    def test_annotated_constants(self):
+        """Test extraction of annotated module-level constants."""
+        # Write a module with annotated constants
+        source = dedent("""
+        CONST_INT: int = 42
+        CONST_STR: str = "hello"
+        CONST_DICT: dict = {"key": "value"}
+        """)
+        self.temp_file.write_text(source)
+
+        # Load module globals
+        result = task_defaults._load_module_globals("test_globals")
+
+        # Should extract all annotated constants
+        self.assertEqual(result["CONST_INT"], 42)
+        self.assertEqual(result["CONST_STR"], "hello")
+        self.assertEqual(result["CONST_DICT"], {"key": "value"})
+
+
+class TestEvaluateExpression(unittest.TestCase):
+    """Tests for the _evaluate_expression helper function."""
+
+    def test_simple_literal(self):
+        """Test evaluation of a simple literal expression."""
+        # Parse a simple literal
+        node = ast.parse("42").body[0].value
+
+        # Evaluate it with empty context
+        result = task_defaults._evaluate_expression(node, {})
+
+        # Should return the literal value
+        self.assertEqual(result, 42)
+
+    def test_name_reference(self):
+        """Test evaluation of a name that references a local constant."""
+        # Parse a name node
+        node = ast.parse("CONST").body[0].value
+
+        # Evaluate with a constant in the context
+        result = task_defaults._evaluate_expression(node, {"CONST": 100})
+
+        # Should resolve to the constant value
+        self.assertEqual(result, 100)
+
+    def test_name_not_in_context(self):
+        """Test evaluation of a name not present in the context returns None."""
+        # Parse a name node
+        node = ast.parse("UNKNOWN").body[0].value
+
+        # Evaluate with empty context
+        result = task_defaults._evaluate_expression(node, {})
+
+        # Should return None
+        self.assertIsNone(result)
+
+    def test_os_environ_get_with_default(self):
+        """Test evaluation of os.environ.get() with a default value."""
+        # Parse an os.environ.get call with default
+        node = ast.parse('os.environ.get("MISSING_VAR", "fallback")').body[0].value
+
+        # Evaluate (variable doesn't exist, should use default)
+        result = task_defaults._evaluate_expression(node, {})
+
+        # Should return the fallback value
+        self.assertEqual(result, "fallback")
+
+    def test_os_getenv_call(self):
+        """Test evaluation of os.getenv() call."""
+        # Set an environment variable
+        os.environ["TEST_GETENV"] = "value"
+
+        # Parse an os.getenv call
+        node = ast.parse('os.getenv("TEST_GETENV")').body[0].value
+
+        try:
+            # Evaluate the call
+            result = task_defaults._evaluate_expression(node, {})
+
+            # Should return the environment variable value
+            self.assertEqual(result, "value")
+        finally:
+            # Clean up
+            del os.environ["TEST_GETENV"]
+
+
+class TestExtractValue(unittest.TestCase):
+    """Tests for the _extract_value helper function."""
+
+    def test_simple_literal(self):
+        """Test extraction of a simple literal value."""
+        # Parse a simple integer literal
+        node = ast.parse("42").body[0].value
+
+        # Extract the value
+        result = task_defaults._extract_value(node)
+
+        # Should return the literal
+        self.assertEqual(result, 42)
+
+    def test_name_in_globals_map(self):
+        """Test extraction of a name that exists in the globals map."""
+        # Parse a name reference
+        node = ast.parse("CONST").body[0].value
+
+        # Extract with globals map
+        result = task_defaults._extract_value(node, globals_map={"CONST": 99})
+
+        # Should resolve to the global constant
+        self.assertEqual(result, 99)
+
+    def test_name_not_in_maps(self):
+        """Test that a name not in any map returns the identifier string."""
+        # Parse a name reference
+        node = ast.parse("UNKNOWN").body[0].value
+
+        # Extract without any maps
+        result = task_defaults._extract_value(node)
+
+        # Should return the name as a string
+        self.assertEqual(result, "UNKNOWN")
+
+    def test_attribute_chain(self):
+        """Test extraction of an attribute chain (e.g., module.Class)."""
+        # Parse an attribute chain
+        node = ast.parse("module.Class").body[0].value
+
+        # Extract the value
+        result = task_defaults._extract_value(node)
+
+        # Should return the dotted name
+        self.assertEqual(result, "module.Class")
+
+    def test_luigi_parameter_with_keyword_default(self):
+        """Test extraction of default from a luigi parameter call with keyword."""
+        # Parse a luigi parameter call with keyword default
+        node = ast.parse("luigi.IntParameter(default=10)").body[0].value
+
+        # Extract the default value
+        result = task_defaults._extract_value(node)
+
+        # Should return the default value
+        self.assertEqual(result, 10)
+
+    def test_luigi_parameter_with_positional_default(self):
+        """Test extraction of default from a luigi parameter call with positional arg."""
+        # Parse a luigi parameter call with positional default
+        node = ast.parse("luigi.Parameter('default_value')").body[0].value
+
+        # Extract the default value
+        result = task_defaults._extract_value(node)
+
+        # Should return the first positional argument
+        self.assertEqual(result, "default_value")
+
+    def test_unsupported_expression(self):
+        """Test that unsupported expressions return None."""
+        # Parse a lambda expression (unsupported)
+        node = ast.parse("lambda x: x + 1").body[0].value
+
+        # Extract the value
+        result = task_defaults._extract_value(node)
+
+        # Should return None
+        self.assertIsNone(result)
+
+
+class TestSafeLiteralEval(unittest.TestCase):
+    """Tests for the _safe_literal_eval helper function."""
+
+    def test_valid_literal(self):
+        """Test evaluation of a valid literal."""
+        # Parse a valid literal
+        node = ast.parse("42").body[0].value
+
+        # Evaluate safely
+        result = task_defaults._safe_literal_eval(node)
+
+        # Should return the value
+        self.assertEqual(result, 42)
+
+    def test_invalid_expression(self):
+        """Test that invalid expressions return None."""
+        # Parse an invalid expression (function call)
+        node = ast.parse("func()").body[0].value
+
+        # Evaluate safely
+        result = task_defaults._safe_literal_eval(node)
+
+        # Should return None
+        self.assertIsNone(result)
+
+    def test_list_literal(self):
+        """Test evaluation of a list literal."""
+        # Parse a list literal
+        node = ast.parse("[1, 2, 3]").body[0].value
+
+        # Evaluate safely
+        result = task_defaults._safe_literal_eval(node)
+
+        # Should return the list
+        self.assertEqual(result, [1, 2, 3])
+
+    def test_dict_literal(self):
+        """Test evaluation of a dictionary literal."""
+        # Parse a dict literal
+        node = ast.parse("{'key': 'value'}").body[0].value
+
+        # Evaluate safely
+        result = task_defaults._safe_literal_eval(node)
+
+        # Should return the dictionary
+        self.assertEqual(result, {"key": "value"})
+
+
+class TestMergeConfigWithDefaults(unittest.TestCase):
+    """Tests for the merge_config_with_defaults function."""
+
+    def test_merge_with_override(self):
+        """Test that user config values override defaults."""
+        # Define config with override
+        config = {"TaskA": {"param": 1}}
+        defaults = {"TaskA": {"param": 0, "threshold": 0.5}}
+
+        # Merge config with defaults
+        result = task_defaults.merge_config_with_defaults(config, defaults)
+
+        # User value should override default
+        self.assertEqual(result["TaskA"]["param"], 1)
+        # Default value should be added
+        self.assertEqual(result["TaskA"]["threshold"], 0.5)
+
+    def test_merge_adds_missing_defaults(self):
+        """Test that missing parameters are added from defaults."""
+        # Define config with partial params
+        config = {"TaskA": {"param": 1}}
+        defaults = {"TaskA": {"param": 0, "threshold": 0.5, "enabled": True}}
+
+        # Merge config with defaults
+        result = task_defaults.merge_config_with_defaults(config, defaults)
+
+        # All default params should be present
+        expected = {"param": 1, "threshold": 0.5, "enabled": True}
+        self.assertEqual(result["TaskA"], expected)
+
+    def test_task_not_in_defaults(self):
+        """Test that tasks not in defaults are retained unchanged."""
+        # Define config with a task not in defaults
+        config = {"ExtraTask": {"value": 42}}
+        defaults = {"TaskA": {"param": 0}}
+
+        # Merge config with defaults
+        result = task_defaults.merge_config_with_defaults(config, defaults)
+
+        # ExtraTask should be retained as-is
+        self.assertEqual(result["ExtraTask"], {"value": 42})
+
+    def test_undefined_param_in_config_removed(self):
+        """Test that parameters in config but not in defaults are removed."""
+        # Define config with an undefined parameter
+        config = {"TaskA": {"param": 1, "undefined_param": None}}
+        defaults = {"TaskA": {"param": 0, "threshold": 0.5}}
+
+        # Merge config with defaults
+        result = task_defaults.merge_config_with_defaults(config, defaults)
+
+        # undefined_param should not be in the result
+        self.assertNotIn("undefined_param", result["TaskA"])
+        # Only valid params should be present
+        expected = {"param": 1, "threshold": 0.5}
+        self.assertEqual(result["TaskA"], expected)
+
+    def test_empty_config(self):
+        """Test merging with an empty config dictionary."""
+        # Define empty config
+        config = {}
+        defaults = {"TaskA": {"param": 0}}
+
+        # Merge empty config with defaults
+        result = task_defaults.merge_config_with_defaults(config, defaults)
+
+        # Result should be empty
+        self.assertEqual(result, {})
+
+    def test_empty_defaults(self):
+        """Test merging with empty defaults dictionary."""
+        # Define config with empty defaults
+        config = {"TaskA": {"param": 1}}
+        defaults = {}
+
+        # Merge config with empty defaults
+        result = task_defaults.merge_config_with_defaults(config, defaults)
+
+        # Config should be retained as-is
+        self.assertEqual(result["TaskA"], {"param": 1})
+
+
+class TestUpdateConfigWithDefaults(unittest.TestCase):
+    """Tests for the update_config_with_defaults function."""
+
+    def setUp(self):
+        """Create temporary module files for testing."""
+        # Create temporary directory
+        self.temp_dir = tempfile.mkdtemp()
+        self.module_a_file = Path(self.temp_dir) / "module_a.py"
+        self.module_b_file = Path(self.temp_dir) / "module_b.py"
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        # Remove temporary files and directory
+        if self.module_a_file.exists():
+            self.module_a_file.unlink()
+        if self.module_b_file.exists():
+            self.module_b_file.unlink()
+        if Path(self.temp_dir).exists():
+            Path(self.temp_dir).rmdir()
+
+    def test_update_with_module_mapping(self):
+        """Test updating config with a custom module mapping."""
+        # Write module A with TaskA
+        source_a = dedent("""
+        class TaskA:
+            param1 = 10
+            param2 = "default"
+        """)
+        self.module_a_file.write_text(source_a)
+
+        # Write module B with TaskB
+        source_b = dedent("""
+        class TaskB:
+            enabled = False
+        """)
+        self.module_b_file.write_text(source_b)
+
+        # Define config and module mapping
+        config = {
+            "TaskA": {"param1": 20},
+            "TaskB": {"enabled": True}
+        }
+        module_mapping = {
+            "TaskA": self.module_a_file,
+            "TaskB": self.module_b_file
+        }
+
+        # Update config with defaults
+        result = task_defaults.update_config_with_defaults(config, module_mapping)
+
+        # Check TaskA merged correctly
+        self.assertEqual(result["TaskA"]["param1"], 20)  # overridden
+        self.assertEqual(result["TaskA"]["param2"], "default")  # added from defaults
+
+        # Check TaskB merged correctly
+        self.assertEqual(result["TaskB"]["enabled"], True)  # overridden
+
+    def test_task_not_in_mapping(self):
+        """Test that tasks not in module mapping are skipped."""
+        # Define config with a task not in mapping
+        config = {"TaskA": {"param": 1}, "UnknownTask": {"value": 2}}
+        module_mapping = {}  # Empty mapping
+
+        # Update config with defaults
+        result = task_defaults.update_config_with_defaults(config, module_mapping)
+
+        # Result should be empty (no tasks in mapping)
+        self.assertEqual(result, {})
+
+
+class TestUpdateTomlWithDefaults(unittest.TestCase):
+    """Tests for the update_toml_with_defaults function."""
+
+    def setUp(self):
+        """Create temporary TOML file and module for testing."""
+        # Create temporary directory and files
+        self.temp_dir = tempfile.mkdtemp()
+        self.toml_file = Path(self.temp_dir) / "config.toml"
+        self.module_file = Path(self.temp_dir) / "test_module.py"
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        # Remove temporary files and directory
+        if self.toml_file.exists():
+            self.toml_file.unlink()
+        if self.module_file.exists():
+            self.module_file.unlink()
+        if Path(self.temp_dir).exists():
+            Path(self.temp_dir).rmdir()
+
+    def test_update_toml_file(self):
+        """Test updating a TOML file with defaults from a module."""
+        # Write a module with a task
+        source = dedent("""
+        class TaskA:
+            param1 = 10
+            param2 = "default"
+        """)
+        self.module_file.write_text(source)
+
+        # Write a TOML config file
+        import toml
+        config = {"TaskA": {"param1": 20}}
+        with open(self.toml_file, "w") as f:
+            toml.dump(config, f)
+
+        # Define module mapping
+        module_mapping = {"TaskA": self.module_file}
+
+        # Update TOML with defaults
+        result = task_defaults.update_toml_with_defaults(self.toml_file, module_mapping)
+
+        # Check merged result
+        self.assertEqual(result["TaskA"]["param1"], 20)  # overridden
+        self.assertEqual(result["TaskA"]["param2"], "default")  # added from defaults
+
+    def test_nonexistent_toml_file_raises(self):
+        """Test that a non-existent TOML file raises FileNotFoundError."""
+        # Use a path that doesn't exist
+        nonexistent_toml = Path("/nonexistent/path/config.toml")
+
+        # Should raise FileNotFoundError
+        with self.assertRaises(FileNotFoundError):
+            task_defaults.update_toml_with_defaults(nonexistent_toml)
+
+    def test_invalid_toml_syntax(self):
+        """Test that invalid TOML syntax raises TomlDecodeError."""
+        import toml
+
+        # Write invalid TOML content
+        self.toml_file.write_text("[[invalid toml")
+
+        # Should raise TomlDecodeError
+        with self.assertRaises(toml.TomlDecodeError):
+            task_defaults.update_toml_with_defaults(self.toml_file)
+
+
+class TestIntegrationScenarios(unittest.TestCase):
+    """Integration tests for complete workflows."""
+
+    def setUp(self):
+        """Create temporary files for integration testing."""
+        # Create temporary directory and files
+        self.temp_dir = tempfile.mkdtemp()
+        self.module_file = Path(self.temp_dir) / "tasks.py"
+        self.toml_file = Path(self.temp_dir) / "config.toml"
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        # Remove temporary files and directory
+        if self.module_file.exists():
+            self.module_file.unlink()
+        if self.toml_file.exists():
+            self.toml_file.unlink()
+        if Path(self.temp_dir).exists():
+            Path(self.temp_dir).rmdir()
+
+    def test_full_workflow_extract_merge_update(self):
+        """Test the complete workflow: extract defaults, merge with config, update TOML."""
+        # Write a module with multiple tasks
+        source = dedent("""
+        import luigi
+
+        GLOBAL_TIMEOUT = 300
+
+        class TaskA:
+            timeout = GLOBAL_TIMEOUT
+            retry = luigi.IntParameter(default=3)
+            enabled = True
+
+        class TaskB:
+            count: int = 10
+            name = "task_b"
+        """)
+        self.module_file.write_text(source)
+
+        # Write initial TOML config
+        import toml
+        config = {
+            "TaskA": {"retry": 5},  # override
+            "TaskB": {"count": 20}  # override
+        }
+        with open(self.toml_file, "w") as f:
+            toml.dump(config, f)
+
+        # Step 1: Extract defaults from module
+        defaults = task_defaults.get_all_task_defaults(self.module_file)
+
+        # Verify extracted defaults
+        self.assertEqual(defaults["TaskA"]["timeout"], 300)
+        self.assertEqual(defaults["TaskA"]["retry"], 3)
+        self.assertEqual(defaults["TaskB"]["count"], 10)
+
+        # Step 2: Merge config with defaults
+        merged = task_defaults.merge_config_with_defaults(config, defaults)
+
+        # Verify merged config
+        self.assertEqual(merged["TaskA"]["retry"], 5)  # overridden
+        self.assertEqual(merged["TaskA"]["timeout"], 300)  # added
+        self.assertEqual(merged["TaskB"]["count"], 20)  # overridden
+        self.assertEqual(merged["TaskB"]["name"], "task_b")  # added
+
+        # Step 3: Update TOML with defaults
+        module_mapping = {"TaskA": self.module_file, "TaskB": self.module_file}
+        result = task_defaults.update_toml_with_defaults(self.toml_file, module_mapping)
+
+        # Verify final result
+        self.assertEqual(result["TaskA"]["retry"], 5)
+        self.assertEqual(result["TaskA"]["timeout"], 300)
+        self.assertEqual(result["TaskB"]["count"], 20)
+        self.assertEqual(result["TaskB"]["name"], "task_b")
+
+    def test_complex_import_resolution(self):
+        """Test handling of imported constants and symbols."""
+        # Write a module that imports and uses external symbols
+        source = dedent("""
+        from pathlib import Path
+
+        BASE_DIR = Path("/tmp")
+
+        class Task:
+            output_dir = BASE_DIR
+        """)
+        self.module_file.write_text(source)
+
+        # Extract defaults (should handle the import)
+        defaults = task_defaults.get_all_task_defaults(self.module_file)
+
+        # Verify that BASE_DIR was resolved
+        # Since it references Path("/tmp"), it should be converted to string or Path
+        self.assertIn("output_dir", defaults["Task"])
+
+    def test_nested_dict_and_list_defaults(self):
+        """Test extraction and merging of nested dictionaries and lists."""
+        # Write a module with nested structures
+        source = dedent("""
+        class Task:
+            config = {"nested": {"key": "value"}}
+            items = [1, [2, 3], 4]
+        """)
+        self.module_file.write_text(source)
+
+        # Extract defaults
+        defaults = task_defaults.get_all_task_defaults(self.module_file)
+
+        # Verify nested structures are preserved
+        self.assertEqual(defaults["Task"]["config"], {"nested": {"key": "value"}})
+        self.assertEqual(defaults["Task"]["items"], [1, [2, 3], 4])
+
+        # Test merging with overrides
+        config = {"Task": {"config": {"nested": {"key": "override"}}}}
+        merged = task_defaults.merge_config_with_defaults(config, defaults)
+
+        # Note: merge is shallow, so nested dict is replaced entirely
+        self.assertEqual(merged["Task"]["config"], {"nested": {"key": "override"}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Summary of changes**
- Refactored `update_config` in `romi_run_task.py` with explicit merging logic and improved logging.
- Added `--cfg` CLI option and `cfg_override` parameter to allow TOML‑string overrides of the configuration.
- Migrated all TOML loading/dumping to **tomlkit** with UTF‑8 file handling and compatibility sanitisation for backup configs.
- Tightened typing and ensured TOML‑compatible dumping in `create_backup_cfg`.
- Introduced `keep_task` luigi parameter in `FilesetTarget` to preserve filesets (and upstream tasks) during cleaning, with graph‑based ancestor computation.
- Implemented inheritance‑aware default extraction (`get_inherited_defaults`, etc.) and integrated it into the `romi_run_task` workflow via `update_config_with_defaults`.
- Added comprehensive unit tests for task‑default utilities and strengthened error handling for AST evaluation and module imports.
- Updated docstrings, usage examples, and inline comments to reflect the new functionality and improved robustness.