### PR TITLE
Improve failed pipeline handling, fix config and fix logger backup

### DIFF
--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -345,7 +345,8 @@ def create_backup_cfg(path: str | Path, cfgname: str, config: dict[str, dict[str
     compat_cfg = copy.copy(config)
     for task_name, task_params in compat_cfg.items():
         # Convert any list or dict task parameter value to a string for compatibility:
-        compat_cfg[task_name] = {param_name: str(param) if isinstance(param, (list, dict)) else param for param_name, param in task_params.items()}
+        compat_cfg[task_name] = {param_name: str(param) if isinstance(param, (list, dict)) else param for
+                                 param_name, param in task_params.items()}
         # Exclude `None` from the config
         compat_cfg[task_name] = {param_name: param for param_name, param in task_params.items() if param is not None}
 

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -530,7 +530,7 @@ def run_task(dataset_path: str | Path,
         local_config = {}
         logger.info(f"Found {len(local_toml)} local TOML configuration file{'s' if len(local_toml) > 1 else ''}!")
         for f in local_toml:
-           local_config = update_config(local_config, load_config_from_file(str(f), logger=logger))
+            local_config = update_config(local_config, load_config_from_file(str(f), logger=logger))
         if local_config != {}:
             logger.info(f"Got local definitions for: {list(local_config.keys())}")
             logger.debug(f"{local_config=}")
@@ -551,9 +551,9 @@ def run_task(dataset_path: str | Path,
     with tempfile.TemporaryDirectory() as tmpd:
         # Get the log_file name, with the date & task name by default:
         log_fname = kwargs.get('log_fname', get_log_filename(task))
+        logfile_path = os.path.join(tmpd, log_fname)
         # - Get logging configuration string for luigi, specifying the log file name :
-        logging_config = get_logging_config(log_level=log_level,
-                                            logfile_path=os.path.join(tmpd, log_fname))
+        logging_config = get_logging_config(log_level=log_level, logfile_path=logfile_path)
         # - Create a "logging.cfg" file to be used by `luigi`:
         logging_file_path = os.path.join(tmpd, "logging.cfg")
         with open(logging_file_path, 'w') as f:
@@ -608,6 +608,25 @@ def run_task(dataset_path: str | Path,
             delta = str(delta).split('.')[0]  # to get HH:MM:SS
             if p.returncode == 0:
                 logger.info(f"Done in {delta}s!")
+                # Move the temporary logging configuration and backup TOML file
+                # to the actual dataset directory after the task has created it.
+                # This must happen **after** the subprocess call because the
+                # dataset directory is created by the task itself.
+                try:
+                    # Move logging.cfg
+                    shutil.move(logfile_path, Path(dataset_path) / log_fname)
+                    # Move the backup configuration file (scan.toml or pipeline.toml)
+                    # Ensure the destination file is overwritten if it already exists.
+                    dest_cfg_path = Path(dataset_path) / Path(cfg_file_path).name
+                    if dest_cfg_path.exists():
+                        try:
+                            dest_cfg_path.unlink()  # Remove the existing file first
+                        except Exception as e_unlink:
+                            logger.error(f"Could not remove existing config file '{dest_cfg_path}': {e_unlink}")
+                            raise
+                    shutil.move(cfg_file_path, dest_cfg_path)
+                except Exception as move_err:
+                    logger.error(f"Failed to move temporary config files: {move_err}")
             else:
                 logger.info(f"Failed after {delta}s!")
             # -------------------------------------------------------------

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -602,10 +602,14 @@ def run_task(dataset_path: str | Path,
             logger.info(f"Running luigi command:\n{' '.join(list(map(str, cmd)))}")
             logger.debug(f"Using locally defined varenv: {env}")
             logger.debug(f"Using globally defined varenv: {os.environ}")
+
             # System‑wide variables (`os.environ`) overwrite any duplicate keys from the custom `env` dict
-            p = subprocess.run(cmd, env={**env, **os.environ}, check=True)
+            # Use `check=False` to avoid raising on non‑zero exit; we will handle failures manually.
+            p = subprocess.run(cmd, env={**env, **os.environ}, check=False)
+
             delta = timedelta(seconds=time.time() - t_start)
             delta = str(delta).split('.')[0]  # to get HH:MM:SS
+
             if p.returncode == 0:
                 logger.info(f"Done in {delta}s!")
                 # Move the temporary logging configuration and backup TOML file
@@ -629,27 +633,10 @@ def run_task(dataset_path: str | Path,
                     logger.error(f"Failed to move temporary config files: {move_err}")
             else:
                 logger.info(f"Failed after {delta}s!")
-            # -------------------------------------------------------------
-            # Move the temporary logging configuration and backup TOML file
-            # to the actual dataset directory after the task has created it.
-            # This must happen **after** the subprocess call because the
-            # dataset directory is created by the task itself.
-            try:
-                # Move logging.cfg
-                shutil.move(logging_file_path, Path(dataset_path) / log_fname)
-                # Move the backup configuration file (scan.toml or pipeline.toml)
-                # Ensure the destination file is overwritten if it already exists.
-                dest_cfg_path = Path(dataset_path) / Path(cfg_file_path).name
-                if dest_cfg_path.exists():
-                    try:
-                        dest_cfg_path.unlink()  # Remove the existing file first
-                    except Exception as e_unlink:
-                        logger.error(f"Could not remove existing config file '{dest_cfg_path}': {e_unlink}")
-                        raise
-                shutil.move(cfg_file_path, dest_cfg_path)
-            except Exception as move_err:
-                logger.error(f"Failed to move temporary config files: {move_err}")
-            # -------------------------------------------------------------
+                failed_tmp_workdir = tmpd + "_failed"
+                shutil.copytree(tmpd, failed_tmp_workdir, copy_function=shutil.copy2)
+                logger.info(f"Moved failed temporary working directory to: {failed_tmp_workdir}")
+
     return p
 
 

--- a/src/romitask/cli/romi_run_task.py
+++ b/src/romitask/cli/romi_run_task.py
@@ -346,7 +346,8 @@ def create_backup_cfg(path: str | Path, cfgname: str, config: dict[str, dict[str
     for task_name, task_params in compat_cfg.items():
         # Convert any list or dict task parameter value to a string for compatibility:
         compat_cfg[task_name] = {param_name: str(param) if isinstance(param, (list, dict)) else param for param_name, param in task_params.items()}
-        compat_cfg[task_name] = {param_name: param for param_name, param in task_params.items() if param}
+        # Exclude `None` from the config
+        compat_cfg[task_name] = {param_name: param for param_name, param in task_params.items() if param is not None}
 
     with open(file_path, 'w') as f:
         tomlkit.dump(compat_cfg, f)


### PR DESCRIPTION

- Change `subprocess.run(..., check=True)` to `check=False`, handle non‑zero return codes manually, and archive the temporary working directory to a `*_failed` folder when a task fails.  
- After a successful run, move the temporary logging configuration file and the backup TOML files (`scan.toml` or `pipeline.toml`) into the created dataset directory, overwriting existing files and logging any errors.  
- Refine backup config generation to filter out only `None` values (`if param is not None`) instead of all falsy values, preserving valid falsy parameters.  
- Fix indentation on the `local_config` update line for consistency.